### PR TITLE
Styles: Implement fonts, links, and colors

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/assets/ponyfill.css
+++ b/source/wp-content/themes/wporg-news-2021/assets/ponyfill.css
@@ -224,25 +224,19 @@ input[type=checkbox] + label {
 }
 
 @media (min-width: 480px) {
-	h1 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h1--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h1--typography--line-height);
-	}
-	h2 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h2--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h2--typography--line-height);
-	}
-	h3 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h3--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h3--typography--line-height);
-	}
-	h4 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h4--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h4--typography--line-height);
-	}
-	h5 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h5--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h5--typography--line-height);
+	/**
+	 * Changing the values of the CSS variables works better than redeclaring the attributes because
+	 * of some issues with precedence, especially in the block editor.
+	 */
+	body {
+		--wp--custom--h1--typography--font-size: var(--wp--custom--h1--breakpoint--mobile--typography--font-size);
+		--wp--custom--h1--typography--line-height: var(--wp--custom--h1--breakpoint--mobile--typography--line-height);
+		--wp--custom--h2--typography--font-size: var(--wp--custom--h2--breakpoint--mobile--typography--font-size);
+		--wp--custom--h3--typography--font-size: var(--wp--custom--h3--breakpoint--mobile--typography--font-size);
+		--wp--custom--h3--typography--line-height: var(--wp--custom--h3--breakpoint--mobile--typography--line-height);
+		--wp--custom--h4--typography--font-size: var(--wp--custom--h4--breakpoint--mobile--typography--font-size);
+		--wp--custom--h5--typography--font-size: var(--wp--custom--h5--breakpoint--mobile--typography--font-size);
+		--wp--custom--h5--typography--line-height: var(--wp--custom--h5--breakpoint--mobile--typography--line-height);
 	}
 }
 

--- a/source/wp-content/themes/wporg-news-2021/assets/ponyfill.css
+++ b/source/wp-content/themes/wporg-news-2021/assets/ponyfill.css
@@ -161,27 +161,6 @@ p, h1, h2, h3, h4, h5, h6 {
  * Elements
  * - Styles for basic HTML elemants
  */
-a {
-	cursor: pointer;
-	text-underline-offset: 0.15em;
-	text-decoration: none;
-}
-
-a:hover, a:focus {
-	text-decoration-line: underline;
-}
-
-.block-editor-block-list__layout a,
-.wp-block-post-content a {
-	text-decoration-line: underline;
-}
-
-.block-editor-block-list__layout a:hover, .block-editor-block-list__layout a:focus,
-.wp-block-post-content a:hover,
-.wp-block-post-content a:focus {
-	text-decoration: none;
-}
-
 input.wp-block-search__input,
 input[type="text"],
 input[type="email"],
@@ -242,6 +221,50 @@ input[type=checkbox] + label {
 	display: inline;
 	margin-left: 0.5em;
 	line-height: 1em;
+}
+
+@media (min-width: 480px) {
+	h1 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h1--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h1--typography--line-height);
+	}
+	h2 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h2--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h2--typography--line-height);
+	}
+	h3 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h3--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h3--typography--line-height);
+	}
+	h4 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h4--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h4--typography--line-height);
+	}
+	h5 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h5--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h5--typography--line-height);
+	}
+}
+
+a {
+	cursor: pointer;
+	text-underline-offset: 0.15em;
+	text-decoration: none;
+}
+
+a:hover, a:focus {
+	text-decoration-line: underline;
+}
+
+.block-editor-block-list__layout a,
+.wp-block-post-content a {
+	text-decoration-line: underline;
+}
+
+.block-editor-block-list__layout a:hover, .block-editor-block-list__layout a:focus,
+.wp-block-post-content a:hover,
+.wp-block-post-content a:focus {
+	text-decoration: none;
 }
 
 /**

--- a/source/wp-content/themes/wporg-news-2021/assets/ponyfill.css
+++ b/source/wp-content/themes/wporg-news-2021/assets/ponyfill.css
@@ -223,6 +223,13 @@ input[type=checkbox] + label {
 	line-height: 1em;
 }
 
+.editor-post-title .editor-post-title__input {
+	font-family: var(--wp--custom--heading--typography--font-family);
+	font-size: var(--wp--custom--h1--typography--font-size);
+	font-weight: var(--wp--custom--h1--typography--font-weight);
+	line-height: var(--wp--custom--h1--typography--line-height);
+}
+
 @media (min-width: 480px) {
 	/**
 	 * Changing the values of the CSS variables works better than redeclaring the attributes because

--- a/source/wp-content/themes/wporg-news-2021/assets/ponyfill.css
+++ b/source/wp-content/themes/wporg-news-2021/assets/ponyfill.css
@@ -25,6 +25,12 @@ img {
  * Breakpoints & Media Queries
  */
 /**
+*  Converts a hex value into the rgb equivalent.
+*
+* @param {string} hex - the hexadecimal value to convert
+* @return {string} comma separated rgb values
+*/
+/**
  * Breakpoint mixins
  */
 /**
@@ -51,9 +57,6 @@ img {
  */
 /**
  * Reset the WP Admin page styles for Gutenberg-like pages.
- */
-/**
- * These are default block editor widths in case the theme doesn't provide them.
  */
 .wp-block-group.alignfull,
 *[class*="wp-container-"] {
@@ -130,11 +133,11 @@ body.admin-bar .wp-site-blocks {
 }
 
 ::selection {
-	background-color: var(--wp--custom--color--selection);
+	background-color: var(--wp--preset--color--coral-red);
 }
 
 ::-moz-selection {
-	background-color: var(--wp--custom--color--selection);
+	background-color: var(--wp--preset--color--coral-red);
 }
 
 p, h1, h2, h3, h4, h5, h6 {
@@ -249,6 +252,10 @@ input[type=checkbox] + label {
  */
 .wp-block-button.wp-block-button__link,
 .wp-block-button .wp-block-button__link {
+	opacity: 1;
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
@@ -262,34 +269,60 @@ input[type=checkbox] + label {
 	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
-	border-radius: var(--wp--custom--button--border--radius);
-}
-
-.wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-	opacity: 1;
-	color: var(--wp--custom--button--color--text);
-	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
 	border-color: var(--wp--custom--button--border--color);
-}
-
-.wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--text);
+	border-radius: var(--wp--custom--button--border--radius);
 }
 
 .wp-block-button.wp-block-button__link svg,
 .wp-block-button .wp-block-button__link svg {
 	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.wp-block-button__link:hover,
+.wp-block-button .wp-block-button__link:hover {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--border--color);
+}
+
+.wp-block-button.wp-block-button__link:active,
+.wp-block-button .wp-block-button__link:active {
+	color: var(--wp--custom--button--active--color--text);
+	background-color: var(--wp--custom--button--active--color--background);
+	border-color: var(--wp--custom--button--active--border--color);
+}
+
+.wp-block-button.wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link:focus {
+	color: var(--wp--custom--button--focus--color--text);
+	background-color: var(--wp--custom--button--focus--color--background);
+	border-color: var(--wp--custom--button--focus--border--color);
+}
+
+.wp-block-button.wp-block-button__link svg,
+.wp-block-button .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.wp-block-button__link:hover,
+.wp-block-button .wp-block-button__link:hover {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--border--color);
+}
+
+.wp-block-button.wp-block-button__link:active,
+.wp-block-button .wp-block-button__link:active {
+	color: var(--wp--custom--button--active--color--text);
+	background-color: var(--wp--custom--button--active--color--background);
+	border-color: var(--wp--custom--button--active--border--color);
+}
+
+.wp-block-button.wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link:focus {
+	color: var(--wp--custom--button--focus--color--text);
+	background-color: var(--wp--custom--button--focus--color--background);
+	border-color: var(--wp--custom--button--focus--border--color);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link,
@@ -305,33 +338,33 @@ input[type=checkbox] + label {
 	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
-}
-
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-	opacity: 1;
-	color: var(--wp--custom--button--color--text);
-	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
 	border-color: var(--wp--custom--button--border--color);
-}
-
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--text);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link svg,
 .wp-block-button.is-style-outline .wp-block-button__link svg {
 	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:hover,
+.wp-block-button.is-style-outline .wp-block-button__link:hover {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--border--color);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:active,
+.wp-block-button.is-style-outline .wp-block-button__link:active {
+	color: var(--wp--custom--button--active--color--text);
+	background-color: var(--wp--custom--button--active--color--background);
+	border-color: var(--wp--custom--button--active--border--color);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:focus,
+.wp-block-button.is-style-outline .wp-block-button__link:focus {
+	color: var(--wp--custom--button--focus--color--text);
+	background-color: var(--wp--custom--button--focus--color--background);
+	border-color: var(--wp--custom--button--focus--border--color);
 }
 
 .wp-block-buttons .wp-block-button:last-child {
@@ -423,8 +456,12 @@ p.has-background {
 	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
+	opacity: 1;
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-post-comments input[type="submit"] svg,
@@ -432,25 +469,51 @@ p.has-background {
 	fill: var(--wp--custom--button--color--text);
 }
 
-.wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):hover, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):focus, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color).has-focus,
-.wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):hover,
-.wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):focus,
-.wp-block-post-comments .reply a:not(.has-background):not(.has-text-color).has-focus {
-	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-	opacity: 1;
-	color: var(--wp--custom--button--color--text);
-	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
-	border-color: var(--wp--custom--button--border--color);
+.wp-block-post-comments input[type="submit"]:hover,
+.wp-block-post-comments .reply a:hover {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--border--color);
 }
 
-.wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):hover svg, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):focus svg, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color).has-focus svg,
-.wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):hover svg,
-.wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):focus svg,
-.wp-block-post-comments .reply a:not(.has-background):not(.has-text-color).has-focus svg {
+.wp-block-post-comments input[type="submit"]:active,
+.wp-block-post-comments .reply a:active {
+	color: var(--wp--custom--button--active--color--text);
+	background-color: var(--wp--custom--button--active--color--background);
+	border-color: var(--wp--custom--button--active--border--color);
+}
+
+.wp-block-post-comments input[type="submit"]:focus,
+.wp-block-post-comments .reply a:focus {
+	color: var(--wp--custom--button--focus--color--text);
+	background-color: var(--wp--custom--button--focus--color--background);
+	border-color: var(--wp--custom--button--focus--border--color);
+}
+
+.wp-block-post-comments input[type="submit"] svg,
+.wp-block-post-comments .reply a svg {
 	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-post-comments input[type="submit"]:hover,
+.wp-block-post-comments .reply a:hover {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--border--color);
+}
+
+.wp-block-post-comments input[type="submit"]:active,
+.wp-block-post-comments .reply a:active {
+	color: var(--wp--custom--button--active--color--text);
+	background-color: var(--wp--custom--button--active--color--background);
+	border-color: var(--wp--custom--button--active--border--color);
+}
+
+.wp-block-post-comments input[type="submit"]:focus,
+.wp-block-post-comments .reply a:focus {
+	color: var(--wp--custom--button--focus--color--text);
+	background-color: var(--wp--custom--button--focus--color--background);
+	border-color: var(--wp--custom--button--focus--border--color);
 }
 
 .wp-block-post-comments .reply {
@@ -697,8 +760,12 @@ p.has-background {
 	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
+	opacity: 1;
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button svg,
@@ -706,25 +773,51 @@ p.has-background {
 	fill: var(--wp--custom--button--color--text);
 }
 
-.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus {
-	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-	opacity: 1;
-	color: var(--wp--custom--button--color--text);
-	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
-	border-color: var(--wp--custom--button--border--color);
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:hover,
+.wp-block-search .wp-block-search__button:hover {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--border--color);
 }
 
-.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg {
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:active,
+.wp-block-search .wp-block-search__button:active {
+	color: var(--wp--custom--button--active--color--text);
+	background-color: var(--wp--custom--button--active--color--background);
+	border-color: var(--wp--custom--button--active--border--color);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:focus,
+.wp-block-search .wp-block-search__button:focus {
+	color: var(--wp--custom--button--focus--color--text);
+	background-color: var(--wp--custom--button--focus--color--background);
+	border-color: var(--wp--custom--button--focus--border--color);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button svg,
+.wp-block-search .wp-block-search__button svg {
 	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:hover,
+.wp-block-search .wp-block-search__button:hover {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--border--color);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:active,
+.wp-block-search .wp-block-search__button:active {
+	color: var(--wp--custom--button--active--color--text);
+	background-color: var(--wp--custom--button--active--color--background);
+	border-color: var(--wp--custom--button--active--border--color);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:focus,
+.wp-block-search .wp-block-search__button:focus {
+	color: var(--wp--custom--button--focus--color--text);
+	background-color: var(--wp--custom--button--focus--color--background);
+	border-color: var(--wp--custom--button--focus--border--color);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-icon,
@@ -755,8 +848,12 @@ p.has-background {
 	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
+	opacity: 1;
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	display: inline-block;
 }
 
@@ -764,19 +861,44 @@ p.has-background {
 	fill: var(--wp--custom--button--color--text);
 }
 
-.wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):hover, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):focus, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color).has-focus {
-	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-	opacity: 1;
-	color: var(--wp--custom--button--color--text);
-	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
-	border-color: var(--wp--custom--button--border--color);
+.wp-block-file .wp-block-file__button:hover {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--border--color);
 }
 
-.wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color).has-focus svg {
+.wp-block-file .wp-block-file__button:active {
+	color: var(--wp--custom--button--active--color--text);
+	background-color: var(--wp--custom--button--active--color--background);
+	border-color: var(--wp--custom--button--active--border--color);
+}
+
+.wp-block-file .wp-block-file__button:focus {
+	color: var(--wp--custom--button--focus--color--text);
+	background-color: var(--wp--custom--button--focus--color--background);
+	border-color: var(--wp--custom--button--focus--border--color);
+}
+
+.wp-block-file .wp-block-file__button svg {
 	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-file .wp-block-file__button:hover {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--border--color);
+}
+
+.wp-block-file .wp-block-file__button:active {
+	color: var(--wp--custom--button--active--color--text);
+	background-color: var(--wp--custom--button--active--color--background);
+	border-color: var(--wp--custom--button--active--border--color);
+}
+
+.wp-block-file .wp-block-file__button:focus {
+	color: var(--wp--custom--button--focus--color--text);
+	background-color: var(--wp--custom--button--focus--color--background);
+	border-color: var(--wp--custom--button--focus--border--color);
 }
 
 .wp-block-table.is-style-stripes,

--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -6,8 +6,8 @@ namespace WordPressdotorg\Theme\News;
  * Actions and filters.
  */
 add_action( 'after_setup_theme', __NAMESPACE__ . '\theme_support', 9 );
+add_action( 'after_setup_theme', __NAMESPACE__ . '\editor_styles' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
-add_action( 'admin_init', __NAMESPACE__ . '\editor_styles' );
 
 /**
  * Register theme support.
@@ -45,15 +45,6 @@ function theme_support() {
 }
 
 /**
- * Enqueue scripts and styles.
- */
-function enqueue_assets() {
-	// Enqueue Google fonts
-	wp_enqueue_style( 'wporg-news-fonts', fonts_url(), array(), null );
-	wp_enqueue_style( 'wporg-news-ponyfill', get_template_directory_uri() . '/assets/ponyfill.css', array(), wp_get_theme()->get( 'Version' ) );
-}
-
-/**
  * Enqueue editor styles.
  */
 function editor_styles() {
@@ -61,9 +52,18 @@ function editor_styles() {
 	add_editor_style(
 		array(
 			fonts_url(),
-			'/assets/ponyfill.css'
+			'/assets/ponyfill.css',
 		)
 	);
+}
+
+/**
+ * Enqueue scripts and styles.
+ */
+function enqueue_assets() {
+	// Enqueue Google fonts
+	wp_enqueue_style( 'wporg-news-fonts', fonts_url(), array(), null );
+	wp_enqueue_style( 'wporg-news-ponyfill', get_template_directory_uri() . '/assets/ponyfill.css', array(), wp_get_theme()->get( 'Version' ) );
 }
 
 /**

--- a/source/wp-content/themes/wporg-news-2021/sass/base/_text.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_text.scss
@@ -1,10 +1,10 @@
 // Text selection background color
 
 ::selection {
-	background-color: var(--wp--custom--color--selection);
+	background-color: var(--wp--preset--color--coral-red);
 }
 ::-moz-selection {
-	background-color: var(--wp--custom--color--selection);
+	background-color: var(--wp--preset--color--coral-red);
 }
 
 p, h1, h2, h3, h4, h5, h6 {

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_button-mixins.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_button-mixins.scss
@@ -10,9 +10,24 @@
 	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
+	border-color: var(--wp--custom--button--border--color);
 	svg {
 		fill: var(--wp--custom--button--color--text);
+	}
+	&:hover {
+		color: var(--wp--custom--button--hover--color--text);
+		background-color: var(--wp--custom--button--hover--color--background);
+		border-color: var(--wp--custom--button--hover--border--color);
+	}
+	&:active {
+		color: var(--wp--custom--button--active--color--text);
+		background-color: var(--wp--custom--button--active--color--background);
+		border-color: var(--wp--custom--button--active--border--color);
+	}
+	&:focus {
+		color: var(--wp--custom--button--focus--color--text);
+		background-color: var(--wp--custom--button--focus--color--background);
+		border-color: var(--wp--custom--button--focus--border--color);
 	}
 }
 
@@ -42,23 +57,4 @@
 	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
 	padding-left: var(--wp--custom--button--spacing--padding--left);
 	padding-right: var(--wp--custom--button--spacing--padding--right);
-}
-
-
-// NOTE: These remain for the hover styling of blocks.  This can be removed when the button block has configurable hover states.
-// The mechanism below ONLY CHANGES CSS VARIABLES that are already applied to properties (above)
-@mixin button-hover-styles {
-	//The following changes should ONLY be changed if the user has NOT set a custom color
-	&:not(.has-background):not(.has-text-color) {
-		&:hover,
-		&:focus,
-		&.has-focus {
-			//change the color variables to the hover equivalent
-			--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-			--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-			--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-			@include button-color-styles;
-			border-color: var(--wp--custom--button--border--color);
-		}
-	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_button.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_button.scss
@@ -9,7 +9,7 @@
 .wp-block-button {
 	&.wp-block-button__link,
 	.wp-block-button__link {
-		@include button-hover-styles;
+		@include button-color-styles;
 		@include button-main-styles;
 	}
 	&.is-style-outline {
@@ -18,7 +18,6 @@
 			--wp--custom--button--color--text: var(--wp--custom--button--border--color);
 			--wp--custom--button--color--background: transparent;
 			@include button-border-styles;
-			@include button-hover-styles;
 			@include button-color-styles;
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_file.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_file.scss
@@ -3,6 +3,6 @@
 // TODO: Remove when https://github.com/WordPress/gutenberg/issues/27760 is fixed
 .wp-block-file .wp-block-file__button {
 	@include button-main-styles;
-	@include button-hover-styles;
+	@include button-color-styles;
 	display: inline-block;
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-comments.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-comments.scss
@@ -5,10 +5,10 @@
 		font-size: var(--wp--custom--form--label--typography--font-size);
 	}
 
-	input[type="submit"], 
+	input[type="submit"],
 	.reply a {
 		@include button-main-styles;
-		@include button-hover-styles;
+		@include button-color-styles;
 	}
 
 	.reply {

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_search.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_search.scss
@@ -23,7 +23,7 @@
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
 	.wp-block-search__button {
 		@include button-main-styles;
-		@include button-hover-styles;
+		@include button-color-styles;
 		&.has-icon {
 			line-height: 0;
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/elements/_headings.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/elements/_headings.scss
@@ -1,22 +1,16 @@
 @include break-mobile {
-	h1 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h1--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h1--typography--line-height);
-	}
-	h2 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h2--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h2--typography--line-height);
-	}
-	h3 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h3--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h3--typography--line-height);
-	}
-	h4 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h4--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h4--typography--line-height);
-	}
-	h5 {
-		font-size: var(--wp--custom--heading--breakpoint--mobile--h5--typography--font-size);
-		line-height: var(--wp--custom--heading--breakpoint--mobile--h5--typography--line-height);
+	/**
+	 * Changing the values of the CSS variables works better than redeclaring the attributes because
+	 * of some issues with precedence, especially in the block editor.
+	 */
+	body {
+		--wp--custom--h1--typography--font-size: var(--wp--custom--h1--breakpoint--mobile--typography--font-size);
+		--wp--custom--h1--typography--line-height: var(--wp--custom--h1--breakpoint--mobile--typography--line-height);
+		--wp--custom--h2--typography--font-size: var(--wp--custom--h2--breakpoint--mobile--typography--font-size);
+		--wp--custom--h3--typography--font-size: var(--wp--custom--h3--breakpoint--mobile--typography--font-size);
+		--wp--custom--h3--typography--line-height: var(--wp--custom--h3--breakpoint--mobile--typography--line-height);
+		--wp--custom--h4--typography--font-size: var(--wp--custom--h4--breakpoint--mobile--typography--font-size);
+		--wp--custom--h5--typography--font-size: var(--wp--custom--h5--breakpoint--mobile--typography--font-size);
+		--wp--custom--h5--typography--line-height: var(--wp--custom--h5--breakpoint--mobile--typography--line-height);
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/elements/_headings.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/elements/_headings.scss
@@ -1,3 +1,10 @@
+.editor-post-title .editor-post-title__input {
+	font-family: var(--wp--custom--heading--typography--font-family);
+	font-size: var(--wp--custom--h1--typography--font-size);
+	font-weight: var(--wp--custom--h1--typography--font-weight);
+	line-height: var(--wp--custom--h1--typography--line-height);
+}
+
 @include break-mobile {
 	/**
 	 * Changing the values of the CSS variables works better than redeclaring the attributes because

--- a/source/wp-content/themes/wporg-news-2021/sass/elements/_headings.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/elements/_headings.scss
@@ -1,0 +1,22 @@
+@include break-mobile {
+	h1 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h1--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h1--typography--line-height);
+	}
+	h2 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h2--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h2--typography--line-height);
+	}
+	h3 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h3--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h3--typography--line-height);
+	}
+	h4 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h4--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h4--typography--line-height);
+	}
+	h5 {
+		font-size: var(--wp--custom--heading--breakpoint--mobile--h5--typography--font-size);
+		line-height: var(--wp--custom--heading--breakpoint--mobile--h5--typography--line-height);
+	}
+}

--- a/source/wp-content/themes/wporg-news-2021/sass/elements/_style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/elements/_style.scss
@@ -3,5 +3,6 @@
  * - Styles for basic HTML elemants
  */
 
-@import "links";
 @import "forms";
+@import "headings";
+@import "links";

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -155,41 +155,6 @@
 				"secondary": "var(--wp--preset--color--secondary)",
 				"selection": "var(--wp--preset--color--selection)"
 			},
-			"colorPalettes": [
-				{
-					"label": "Featured",
-					"slug": "palette-1",
-					"colors": {
-						"primary": "#C8133E",
-						"secondary": "#4E2F4B",
-						"foreground": "#1D1E1E",
-						"background": "#FFFFFF",
-						"selection": "#F9F9F9"
-					}
-				},
-				{
-					"label": "Featured",
-					"slug": "palette-2",
-					"colors": {
-						"primary": "#35845D",
-						"secondary": "#233252",
-						"foreground": "#242527",
-						"background": "#EEF4F7",
-						"selection": "#F9F9F9"
-					}
-				},
-				{
-					"label": "Featured",
-					"slug": "palette-3",
-					"colors": {
-						"primary": "#9FD3E8",
-						"secondary": "#FBE6AA",
-						"foreground": "#FFFFFF",
-						"background": "#1F2527",
-						"selection": "#364043"
-					}
-				}
-			],
 			"form": {
 				"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
 				"border": {
@@ -521,8 +486,8 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--custom--color--background)",
-			"text": "var(--wp--custom--color--foreground)"
+			"background": "var(--wp--preset--color--white)",
+			"text": "var(--wp--preset--color--black)"
 		},
 		"elements": {
 			"h1": {
@@ -574,9 +539,7 @@
 				}
 			},
 			"link": {
-				"color": {
-					"text": "var(--wp--custom--color--primary)"
-				}
+				"color": "var(--wp--preset--color--blue-1)"
 			}
 		},
 		"typography": {

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -213,6 +213,38 @@
 				}
 			},
 			"heading": {
+				"breakpoint": {
+					"mobile": {
+						"h1": {
+							"typography": {
+								"fontSize": "70px",
+								"lineHeight": "1.1"
+							}
+						},
+						"h2": {
+							"typography": {
+								"fontSize": "50px"
+							}
+						},
+						"h3": {
+							"typography": {
+								"fontSize": "36px",
+								"lineHeight": "1.35"
+							}
+						},
+						"h4": {
+							"typography": {
+								"fontSize": "30px"
+							}
+						},
+						"h5": {
+							"typography": {
+								"fontSize": "26px",
+								"lineHeight": "1.35"
+							}
+						}
+					}
+				},
 				"typography": {
 					"fontWeight": 400,
 					"lineHeight": 1.125
@@ -494,40 +526,40 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "1.1",
-					"fontSize": "70px"
+					"fontSize": "38px",
+					"lineHeight": "1.3"
 				}
 			},
 			"h2": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "1.3",
-					"fontSize": "50px"
+					"fontSize": "30px",
+					"lineHeight": "1.3"
 				}
 			},
 			"h3": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "1.35",
-					"fontSize": "36px"
+					"fontSize": "26px",
+					"lineHeight": "1.3"
 				}
 			},
 			"h4": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "1.3",
-					"fontSize": "30px"
+					"fontSize": "20px",
+					"lineHeight": "1.3"
 				}
 			},
 			"h5": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "1.35",
-					"fontSize": "26px"
+					"fontSize": "20px",
+					"lineHeight": "1.3"
 				}
 			},
 			"h6": {

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -213,41 +213,83 @@
 				}
 			},
 			"heading": {
+				"typography": {
+					"fontWeight": 400,
+					"lineHeight": 1.3
+				}
+			},
+			"h1": {
 				"breakpoint": {
 					"mobile": {
-						"h1": {
-							"typography": {
-								"fontSize": "70px",
-								"lineHeight": "1.1"
-							}
-						},
-						"h2": {
-							"typography": {
-								"fontSize": "50px"
-							}
-						},
-						"h3": {
-							"typography": {
-								"fontSize": "36px",
-								"lineHeight": "1.35"
-							}
-						},
-						"h4": {
-							"typography": {
-								"fontSize": "30px"
-							}
-						},
-						"h5": {
-							"typography": {
-								"fontSize": "26px",
-								"lineHeight": "1.35"
-							}
+						"typography": {
+							"fontSize": "70px",
+							"lineHeight": "1.1"
 						}
 					}
 				},
 				"typography": {
-					"fontWeight": 400,
-					"lineHeight": 1.125
+					"fontSize": "38px",
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+				}
+			},
+			"h2": {
+				"breakpoint": {
+					"mobile": {
+						"typography": {
+							"fontSize": "50px"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "30px",
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+				}
+			},
+			"h3": {
+				"breakpoint": {
+					"mobile": {
+						"typography": {
+							"fontSize": "36px",
+							"lineHeight": "1.35"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "26px",
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+				}
+			},
+			"h4": {
+				"breakpoint": {
+					"mobile": {
+						"typography": {
+							"fontSize": "30px"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "20px",
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+				}
+			},
+			"h5": {
+				"breakpoint": {
+					"mobile": {
+						"typography": {
+							"fontSize": "26px",
+							"lineHeight": "1.35"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "20px",
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},
 			"latest-posts": {
@@ -369,13 +411,13 @@
 					"fontFamily": "'EB Garamond', serif",
 					"slug": "eb-garamond",
 					"name": "EB Garamond",
-					"google": "EB+Garamond:ital,wght@0,400;0,700;1,400;1,700"
+					"google": "family=EB+Garamond:ital,wght@0,400;0,700;1,400;1,700"
 				},
 				{
 					"fontFamily": "'Inter', sans-serif",
 					"slug": "inter",
 					"name": "Inter",
-					"google": "Inter:wght@400;700"
+					"google": "family=Inter:wght@400;700"
 				}
 			],
 			"fontSizes": [
@@ -525,49 +567,49 @@
 			"h1": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "var(--wp--custom--h1--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"fontSize": "38px",
-					"lineHeight": "1.3"
+					"lineHeight": "var(--wp--custom--h1--typography--line-height)"
 				}
 			},
 			"h2": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "var(--wp--custom--h2--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"fontSize": "30px",
-					"lineHeight": "1.3"
+					"lineHeight": "var(--wp--custom--h2--typography--line-height)"
 				}
 			},
 			"h3": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "var(--wp--custom--h3--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"fontSize": "26px",
-					"lineHeight": "1.3"
+					"lineHeight": "var(--wp--custom--h3--typography--line-height)"
 				}
 			},
 			"h4": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "var(--wp--custom--h4--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"fontSize": "20px",
-					"lineHeight": "1.3"
+					"lineHeight": "var(--wp--custom--h4--typography--line-height)"
 				}
 			},
 			"h5": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "var(--wp--custom--h5--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"fontSize": "20px",
-					"lineHeight": "1.3"
+					"lineHeight": "var(--wp--custom--h5--typography--line-height)"
 				}
 			},
 			"h6": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "var(--wp--custom--h6--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "1.3",
-					"fontSize": "var(--wp--preset--font-size--normal)"
+					"lineHeight": "var(--wp--custom--h6--typography--line-height)"
 				}
 			},
 			"link": {

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -329,35 +329,47 @@
 			"customLineHeight": true,
 			"fontFamilies": [
 				{
-					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-					"slug": "system-font",
-					"name": "System Font"
+					"fontFamily": "'EB Garamond', serif",
+					"slug": "eb-garamond",
+					"name": "EB Garamond",
+					"google": "EB+Garamond:ital,wght@0,400;0,700;1,400;1,700"
+				},
+				{
+					"fontFamily": "'Inter', sans-serif",
+					"slug": "inter",
+					"name": "Inter",
+					"google": "Inter:wght@400;700"
 				}
 			],
 			"fontSizes": [
 				{
 					"name": "Tiny",
-					"size": "14px",
+					"size": "12px",
 					"slug": "tiny"
 				},
 				{
 					"name": "Small",
-					"size": "16px",
+					"size": "14px",
 					"slug": "small"
 				},
 				{
 					"name": "Normal",
-					"size": "18px",
+					"size": "16px",
 					"slug": "normal"
 				},
 				{
 					"name": "Large",
-					"size": "24px",
+					"size": "20px",
 					"slug": "large"
 				},
 				{
+					"name": "Extra Large",
+					"size": "24px",
+					"slug": "extra-large"
+				},
+				{
 					"name": "Huge",
-					"size": "28px",
+					"size": "32px",
 					"slug": "huge"
 				}
 			]
@@ -374,7 +386,7 @@
 					"text": "var(--wp--custom--button--color--text)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--inter)",
 					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"fontWeight": "var(--wp--custom--button--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--button--typography--line-height)"
@@ -403,7 +415,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -475,50 +487,50 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "48px"
+					"lineHeight": "1.1",
+					"fontSize": "70px"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "32px"
+					"lineHeight": "1.3",
+					"fontSize": "50px"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "var(--wp--preset--font-size--huge)"
+					"lineHeight": "1.35",
+					"fontSize": "36px"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "var(--wp--preset--font-size--large)"
+					"lineHeight": "1.3",
+					"fontSize": "30px"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "var(--wp--preset--font-size--normal)"
+					"lineHeight": "1.35",
+					"fontSize": "26px"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"lineHeight": "1.3",
+					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
 			"link": {
@@ -529,7 +541,7 @@
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",
-			"fontFamily": "var(--wp--preset--font-family--system-font)",
+			"fontFamily": "var(--wp--preset--font-family--inter)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -406,7 +406,10 @@
 		},
 		"typography": {
 			"customFontSize": true,
-			"customLineHeight": true,
+			"customFontWeight": false,
+			"customLineHeight": false,
+			"customTextDecorations": false,
+			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "'EB Garamond', serif",

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -120,23 +120,41 @@
 				"alignedMaxWidth": "50%"
 			},
 			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--blue-1)",
+					"text": "var(--wp--preset--color--white)"
+				},
 				"border": {
-					"color": "var(--wp--custom--color--primary)",
-					"radius": "4px",
+					"color": "var(--wp--preset--color--blue-1)",
+					"radius": "2px",
 					"style": "solid",
 					"width": "2px"
 				},
-				"color": {
-					"background": "var(--wp--custom--color--primary)",
-					"text": "var(--wp--custom--color--background)"
-				},
 				"hover": {
 					"color": {
-						"text": "var(--wp--custom--color--background)",
-						"background": "var(--wp--custom--color--secondary)"
+						"background": "var(--wp--preset--color--blue-2)",
+						"text": "var(--wp--preset--color--white)"
 					},
 					"border": {
-						"color": "var(--wp--custom--color--secondary)"
+						"color": "var(--wp--preset--color--blue-2)"
+					}
+				},
+				"active": {
+					"color": {
+						"background": "var(--wp--preset--color--black)",
+						"text": "var(--wp--preset--color--white)"
+					},
+					"border": {
+						"color": "var(--wp--preset--color--black)"
+					}
+				},
+				"focus": {
+					"color": {
+						"background": "var(--wp--preset--color--dark-grey)",
+						"text": "var(--wp--preset--color--white)"
+					},
+					"border": {
+						"color": "var(--wp--preset--color--dark-grey)"
 					}
 				},
 				"spacing": {

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -539,7 +539,9 @@
 				}
 			},
 			"link": {
-				"color": "var(--wp--preset--color--blue-1)"
+				"color": {
+					"text": "var(--wp--preset--color--blue-1)"
+				}
 			}
 		},
 		"typography": {

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -39,29 +39,79 @@
 			"gradients": [],
 			"palette": [
 				{
-					"slug": "primary",
-					"color": "#007cba",
-					"name": "Primary"
+					"slug": "black",
+					"color": "#1e1e1e",
+					"name": "Black"
 				},
 				{
-					"slug": "secondary",
-					"color": "#006ba1",
-					"name": "Secondary"
+					"slug": "darker-grey",
+					"color": "#1c2024",
+					"name": "Darker Grey"
 				},
 				{
-					"slug": "foreground",
-					"color": "#333333",
-					"name": "Foreground"
+					"slug": "dark-grey",
+					"color": "#23282d",
+					"name": "Dark Grey"
 				},
 				{
-					"slug": "background",
+					"slug": "dark-strokes-grey",
+					"color": "#2f363d",
+					"name": "Dark Strokes Grey"
+				},
+				{
+					"slug": "light-grey",
+					"color": "#d9d9d9",
+					"name": "Light Grey"
+				},
+				{
+					"slug": "beige",
+					"color": "#e4ddd4",
+					"name": "Beige"
+				},
+				{
+					"slug": "blue-1",
+					"color": "#3e58e1",
+					"name": "Blue 1"
+				},
+				{
+					"slug": "blue-2",
+					"color": "#213fd4",
+					"name": "Blue 2"
+				},
+				{
+					"slug": "blue-3",
+					"color": "#7b90ff",
+					"name": "Blue 3"
+				},
+				{
+					"slug": "blue-4",
+					"color": "#eff2ff",
+					"name": "Blue 4"
+				},
+				{
+					"slug": "off-white",
+					"color": "#f8f3ec",
+					"name": "Off White"
+				},
+				{
+					"slug": "light-salmon",
+					"color": "#ffe9de",
+					"name": "Light Salmon"
+				},
+				{
+					"slug": "green",
+					"color": "#72d1a7",
+					"name": "Green"
+				},
+				{
+					"slug": "coral-red",
+					"color": "#f86368",
+					"name": "Coral Red"
+				},
+				{
+					"slug": "white",
 					"color": "#ffffff",
-					"name": "Background"
-				},
-				{
-					"slug": "selection",
-					"color": "#c2c2c2",
-					"name": "Selection"
+					"name": "White"
 				}
 			]
 		},

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -1,33 +1,5 @@
 {
 	"version": 1,
-	"templateParts": [
-		{
-			"name": "header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"area": "footer"
-		}
-	],
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": [
-				"page",
-				"post"
-			]
-		},
-		{
-			"name": "header-footer-only",
-			"title": "Header and Footer Only",
-			"postTypes": [
-				"page",
-				"post"
-			]
-		}
-	],
 	"settings": {
 		"border": {
 			"customColor": true,
@@ -612,5 +584,33 @@
 			"fontFamily": "var(--wp--preset--font-family--inter)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
 		}
-	}
+	},
+	"customTemplates": [
+		{
+			"name": "blank",
+			"title": "Blank",
+			"postTypes": [
+				"page",
+				"post"
+			]
+		},
+		{
+			"name": "header-footer-only",
+			"title": "Header and Footer Only",
+			"postTypes": [
+				"page",
+				"post"
+			]
+		}
+	],
+	"templateParts": [
+		{
+			"name": "header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"area": "footer"
+		}
+	]
 }

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -214,6 +214,7 @@
 			},
 			"heading": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": 400,
 					"lineHeight": 1.3
 				}
@@ -494,9 +495,9 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontSize": "var(--wp--custom--h1--typography--font-size)",
+					"lineHeight": "var(--wp--custom--h1--typography--line-height)"
 				}
 			},
 			"core/post-date": {
@@ -566,7 +567,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--custom--h1--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--h1--typography--line-height)"
@@ -574,7 +575,7 @@
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--custom--h2--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--h2--typography--line-height)"
@@ -582,7 +583,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--custom--h3--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--h3--typography--line-height)"
@@ -590,7 +591,7 @@
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--custom--h4--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--h4--typography--line-height)"
@@ -598,7 +599,7 @@
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--custom--h5--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--h5--typography--line-height)"
@@ -606,7 +607,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--custom--h6--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--h6--typography--line-height)"

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -131,10 +131,10 @@
 				},
 				"spacing": {
 					"padding": {
-						"top": "0.667em",
-						"bottom": "0.667em",
-						"left": "1.333em",
-						"right": "1.333em"
+						"top": "0.2em",
+						"bottom": "var(--wp--custom--button--spacing--padding--top)",
+						"left": "1em",
+						"right": "var(--wp--custom--button--spacing--padding--left)"
 					}
 				},
 				"typography": {


### PR DESCRIPTION
Adds color palettes, font families, font sizes, and other typography settings to the theme.json file. Also adjusts some things in the stylesheet and in the theme initialization in order for the settings to appear correctly on both the front end and in the block editor.

There's probably plenty more to do related to fonts, links, and colors, but it can be done in other PRs related to specific areas or templates in the theme.