### PR TITLE
"Listen All Episodes" is weird english

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
@@ -65,7 +65,7 @@
 			</ul>
 			<!-- /wp:social-links -->
 			<!-- wp:paragraph {"className":"podcast-link"} -->
-			<p class="podcast-link"><a href="https://wordpress.org/news/podcast/">View All Episodes</a></p>
+			<p class="podcast-link"><a href="https://wordpress.org/news/podcast/">Listen to all episodes</a></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
@@ -65,7 +65,7 @@
 			</ul>
 			<!-- /wp:social-links -->
 			<!-- wp:paragraph {"className":"podcast-link"} -->
-			<p class="podcast-link"><a href="https://wordpress.org/news/podcast/">Listen All Episodes</a></p>
+			<p class="podcast-link"><a href="https://wordpress.org/news/podcast/">View All Episodes</a></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->


### PR DESCRIPTION
I'm not sure how to best rephrase this, "Listen to All Episodes"? "View All Episodes"? "All Episodes"?

The existing text reads weird to me, but the link isn't "listen" or "view"  in the media term, rather it brings you to the list of podcast episodes.. so perhaps "All Episodes" is better here?