### PR TITLE
Refine background for local nav banner

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -225,7 +225,7 @@
 %bottom-mask {
 	position: relative;
 	background-color: transparent;
-    background: linear-gradient(to top, transparent 58px, var( --bar-background-color ) 58px 100%);
+    background: linear-gradient(to top, transparent 56px, var( --bar-background-color ) 56px 100%);
 
 	&:after {
 		content: "";

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -237,7 +237,6 @@
 		z-index: -1;
 		mask-image: url('images/local-nav-mask.svg');
 		mask-repeat: no-repeat;
-		mask-position-x: -20px;
 		mask-size: cover;
 		background-color: var( --bar-background-color );
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -1,14 +1,3 @@
-%bottom-mask {
-	mask-image: url('images/local-nav-mask.svg');
-	mask-repeat: no-repeat;
-	mask-position: -200px -1px;
-	mask-size: cover;
-
-	@include break-small {
-		mask-position-x: -20px;
-	}
-}
-
 // Default/light version.
 .local-header {
 	--bar-text-color: var(--wp--preset--color--white);
@@ -228,6 +217,32 @@
 
 		.local-header {
 			--bar-background-color: var( --wp--preset--color--dark-grey );
+		}
+	}
+}
+
+//We need this at the bottom of the file for proper cascading
+%bottom-mask {
+	position: relative;
+	background-color: transparent;
+    background: linear-gradient(to top, transparent 58px, var( --bar-background-color ) 58px 100%);
+
+	&:after {
+		content: "";
+		height: 58px;
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		z-index: -1;
+		mask-image: url('images/local-nav-mask.svg');
+		mask-repeat: no-repeat;
+		mask-position: -200px -1px;
+		mask-size: cover;
+		background-color: var( --bar-background-color );
+
+		@include break-small {
+			mask-position-x: -20px;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -237,12 +237,8 @@
 		z-index: -1;
 		mask-image: url('images/local-nav-mask.svg');
 		mask-repeat: no-repeat;
-		mask-position: -200px -1px;
+		mask-position-x: -20px;
 		mask-size: cover;
 		background-color: var( --bar-background-color );
-
-		@include break-small {
-			mask-position-x: -20px;
-		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
@@ -11,6 +11,7 @@
 
 		font-size: 7.5rem;
 		color: var(--wp--preset--color--white);
+		padding-bottom: 0.5em;
 	}
 }
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
@@ -24,11 +24,17 @@ body.news-front-page,
 body.news-posts-index,
 body.search,
 body.archive:not(.category) {
+	--bar-background-color: var(--wp--preset--color--blue-1);
 	.local-header {
-		/* Remove mask so this element blends into `query-title-banner`. */
-		background-color: var( --bar-background-color );
-		&:after {
-			content: none;
+		/* Add a background to hide the mask when menu is not open so it blends with `query-title-banner`. */
+		&:before {
+			content: "";
+			position: absolute;
+			height: 56px;
+			top: 0;
+			left: 0;
+			right: 0;
+			background-color: var( --bar-background-color );
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
@@ -26,7 +26,10 @@ body.search,
 body.archive:not(.category) {
 	.local-header {
 		/* Remove mask so this element blends into `query-title-banner`. */
-		mask-image: none;
+		background-color: var( --bar-background-color );
+		&:after {
+			content: none;
+		}
 	}
 
 	.query-title-banner {


### PR DESCRIPTION
This PR refactors the local-header banner to fix the issues outlined in https://github.com/WordPress/wporg-news-2021/issues/67

Now instead of resizing the SVG to fit the content of the dropdown, we are appending it to the bottom of the container inside the `::after` pseudo-element. To keep the background with the correct color for the rest of the dropdown while it's open I'm using a `linear-gradient` that starts right after the SVG.

I think I've covered all cases from the related issue, let me know if I've missed anything.

![Screen Capture on 2021-11-26 at 15-42-55](https://user-images.githubusercontent.com/3593343/143597453-8eb6ad66-1464-49f3-a085-f0f4b0f027ad.gif)

<img width="1423" alt="Screenshot 2021-11-26 at 15 35 49" src="https://user-images.githubusercontent.com/3593343/143596992-981ce4ef-9b96-4231-96ab-a4595e5c8967.png">

<img width="1607" alt="Screenshot 2021-11-26 at 15 35 30" src="https://user-images.githubusercontent.com/3593343/143596997-a936a523-4ed6-4e75-a283-ad7a9b558eb9.png">

Closes https://github.com/WordPress/wporg-news-2021/issues/67