### PR TITLE
Docs: Update order of steps in environment setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"browser-sync": "^2.27.5"
 	},
 	"scripts": {
-		"initial-setup": "yarn && composer install && yarn run update-configs",
+		"initial-setup": "composer install && yarn && yarn run update-configs",
 		"update-configs": "TEXTDOMAIN=wporg composer exec update-configs",
 		"wp-env": "wp-env",
 		"env": "wp-env start",

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,8 @@ This is starting as a fork of [Blockbase](https://github.com/Automattic/themes/t
 ### Setup
 
 1. Set up repo dependencies: `yarn run initial-setup`
-1. Start up and provision the environment: `yarn run env:setup`
 1. Build the assets: `yarn workspaces run build`. The theme can't be activated until this step is done.
+1. Start up and provision the environment: `yarn run env:setup`
 1. Visit site at `localhost:8888`
 1. Log in with username `admin` and password `password`
 


### PR DESCRIPTION
The order of steps in the setup is slightly off what should happen to set up the environment, so I've made two changes here:

1. Switch `yarn` and `composer install` in `initial-setup`: The composer call installs the workspace `wporg-mu-plugins`, which needs its own packages installed, so the `yarn` command needs to come after `composer`.
2. In the readme steps, recommend running `yarn workspaces run build` before `yarn run env:setup`, since one of the steps in `env:setup` activates the theme.

