### PR TITLE
SotW bottom banner improvements

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
@@ -2,8 +2,8 @@
 <div class="wp-block-group alignfull footer-archive-row">
 	<!-- wp:group {"className":"follow-the-code"} -->
 	<div class="wp-block-group follow-the-code">
-		<!-- wp:heading {"level":4} -->
-		<h5>Follow The Code</h5>
+		<!-- wp:heading {"level":3} -->
+		<h3>Follow The Code</h3>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph -->
@@ -14,8 +14,8 @@
 
 	<!-- wp:group {"className":"find-an-event"} -->
 	<div class="wp-block-group find-an-event">
-		<!-- wp:heading {"level":4} -->
-		<h5>Find An Event Near You</h5>
+		<!-- wp:heading {"level":3} -->
+		<h3>Find An Event Near You</h3>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph -->
@@ -30,8 +30,8 @@
 <div class="wp-block-group alignfull footer-archive-row">
 	<!-- wp:group {"className":"subscribe-wp-news"} -->
 	<div class="wp-block-group subscribe-wp-news">
-		<!-- wp:heading {"level":4} -->
-		<h5>Subscribe to WordPress News</h5>
+		<!-- wp:heading {"level":3} -->
+		<h3>Subscribe to WordPress News</h3>
 		<!-- /wp:heading -->
 
 		[jetpack_subscription_form show_only_email_and_button="true" show_subscribers_total="true"]
@@ -40,8 +40,8 @@
 
 	<!-- wp:group {"className":"wp-briefing"} -->
 	<div class="wp-block-group wp-briefing">
-		<!-- wp:heading {"level":4} -->
-		<h5>WP Briefing &mdash; The WordPress Podcast</h5>
+		<!-- wp:heading {"level":3} -->
+		<h3>WP Briefing &mdash; The WordPress Podcast</h3>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"full","classname":"footer-archive"} -->
-<div class="wp-block-group alignfull footer-archive">
+<!-- wp:group {"align":"full"} -->
+<div class="wp-block-group alignfull">
 	<!-- wp:heading {"level":2,"classname":"screen-reader-text"} -->
 	<h2 class="screen-reader-text">Get the Latest Updates</h2>
 	<!-- /wp:heading -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
@@ -1,7 +1,7 @@
 <!-- wp:group {"align":"full","classname":"footer-archive"} -->
 <div class="wp-block-group alignfull footer-archive">
-	<!-- wp:heading {"level":2} -->
-	<h2>Get the Latest Updates</h2>
+	<!-- wp:heading {"level":2,"classname":"screen-reader-text"} -->
+	<h2 class="screen-reader-text">Get the Latest Updates</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:group {"align":"full","className":"footer-archive-row","layout":{"type":"flex"}} -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/footer-archive.html
@@ -1,69 +1,77 @@
-<!-- wp:group {"align":"full","className":"footer-archive-row","layout":{"type":"flex"}} -->
-<div class="wp-block-group alignfull footer-archive-row">
-	<!-- wp:group {"className":"follow-the-code"} -->
-	<div class="wp-block-group follow-the-code">
-		<!-- wp:heading {"level":3} -->
-		<h3>Follow The Code</h3>
-		<!-- /wp:heading -->
+<!-- wp:group {"align":"full","classname":"footer-archive"} -->
+<div class="wp-block-group alignfull footer-archive">
+	<!-- wp:heading {"level":2} -->
+	<h2>Get the Latest Updates</h2>
+	<!-- /wp:heading -->
 
-		<!-- wp:paragraph -->
-		<p><a href="https://make.wordpress.org/core/">There's a development P2</a> blog and you can track active development in the <a href="https://core.trac.wordpress.org/timeline">Trac timeline</a> that often has 20–30 updates per day.</p>
-		<!-- /wp:paragraph -->
-	</div>
-	<!-- /wp:group -->
+	<!-- wp:group {"align":"full","className":"footer-archive-row","layout":{"type":"flex"}} -->
+	<div class="wp-block-group alignfull footer-archive-row">
+		<!-- wp:group {"className":"follow-the-code"} -->
+		<div class="wp-block-group follow-the-code">
+			<!-- wp:heading {"level":3} -->
+			<h3>Follow The Code</h3>
+			<!-- /wp:heading -->
 
-	<!-- wp:group {"className":"find-an-event"} -->
-	<div class="wp-block-group find-an-event">
-		<!-- wp:heading {"level":3} -->
-		<h3>Find An Event Near You</h3>
-		<!-- /wp:heading -->
-
-		<!-- wp:paragraph -->
-		<p>Check out the <a href="https://central.wordcamp.org/">WordCamp schedule</a> and find your <a href="https://www.meetup.com/pro/wordpress">local Meetup group</a>! For more WordPress news, check out the <a href="http://planet.wordpress.org/">WordPress Planet</a>.</p>
-		<!-- /wp:paragraph -->
-	</div>
-	<!-- /wp:group -->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"align":"full","className":"footer-archive-row","layout":{"type":"flex"}} -->
-<div class="wp-block-group alignfull footer-archive-row">
-	<!-- wp:group {"className":"subscribe-wp-news"} -->
-	<div class="wp-block-group subscribe-wp-news">
-		<!-- wp:heading {"level":3} -->
-		<h3>Subscribe to WordPress News</h3>
-		<!-- /wp:heading -->
-
-		[jetpack_subscription_form show_only_email_and_button="true" show_subscribers_total="true"]
-	</div>
-	<!-- /wp:group -->
-
-	<!-- wp:group {"className":"wp-briefing"} -->
-	<div class="wp-block-group wp-briefing">
-		<!-- wp:heading {"level":3} -->
-		<h3>WP Briefing &mdash; The WordPress Podcast</h3>
-		<!-- /wp:heading -->
-
-		<!-- wp:paragraph -->
-		<p>Join Josepha Haden and Matt Mullenweg to learn about where WordPress is going and how you can get involved.</p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:group {"layout":{"type":"flex"}} -->
-		<div class="wp-block-group">
-			<!-- wp:social-links {"iconColor":"blue-1","iconColorValue":"#3e58e1","className":"is-style-logos-only"} -->
-			<ul class="wp-block-social-links has-icon-color is-style-logos-only">
-				<!-- wp:social-link {"url":"https://podcasts.apple.com/us/podcast/wp-briefing/id1551691710","service":"chain","label":"Apple Podcasts","className":"wp-briefing__apple-podcasts"} /-->
-				<!-- wp:social-link {"url":"https://podcasts.google.com/feed/aHR0cHM6Ly93b3JkcHJlc3Mub3JnL25ld3MvZmVlZC9wb2RjYXN0","service":"chain","label":"Google Podcasts","className":"wp-briefing__google-podcasts"} /-->
-				<!-- wp:social-link {"url":"https://pca.st/uqvvmt8t","service":"chain","label":"Pocket Casts","className":"wp-briefing__pocket-casts"} /-->
-				<!-- wp:social-link {"url":"https://wordpress.org/news/feed/podcast","service":"feed","label":"RSS"} /-->
-				<!-- wp:social-link {"url":"https://open.spotify.com/show/6BxgmE9Qg2TZA8EKZLJ4zS","service":"spotify","label":"Spotify"} /-->
-				<!-- wp:social-link {"url":"https://www.stitcher.com/show/wp-briefing","service":"chain","label":"Stitcher","className":"wp-briefing__stitcher"} /-->
-			</ul>
-			<!-- /wp:social-links -->
-
-			<!-- wp:paragraph {"className":"podcast-link"} -->
-			<p class="podcast-link"><a href="https://wordpress.org/news/podcast/">Listen to all episodes</a></p>
+			<!-- wp:paragraph -->
+			<p><a href="https://make.wordpress.org/core/">There's a development P2</a> blog and you can track active development in the <a href="https://core.trac.wordpress.org/timeline">Trac timeline</a> that often has 20–30 updates per day.</p>
 			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"className":"find-an-event"} -->
+		<div class="wp-block-group find-an-event">
+			<!-- wp:heading {"level":3} -->
+			<h3>Find An Event Near You</h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph -->
+			<p>Check out the <a href="https://central.wordcamp.org/">WordCamp schedule</a> and find your <a href="https://www.meetup.com/pro/wordpress">local Meetup group</a>! For more WordPress news, check out the <a href="http://planet.wordpress.org/">WordPress Planet</a>.</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"align":"full","className":"footer-archive-row","layout":{"type":"flex"}} -->
+	<div class="wp-block-group alignfull footer-archive-row">
+		<!-- wp:group {"className":"subscribe-wp-news"} -->
+		<div class="wp-block-group subscribe-wp-news">
+			<!-- wp:heading {"level":3} -->
+			<h3>Subscribe to WordPress News</h3>
+			<!-- /wp:heading -->
+
+			[jetpack_subscription_form show_only_email_and_button="true" show_subscribers_total="true"]
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"className":"wp-briefing"} -->
+		<div class="wp-block-group wp-briefing">
+			<!-- wp:heading {"level":3} -->
+			<h3>WP Briefing &mdash; The WordPress Podcast</h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph -->
+			<p>Join Josepha Haden and Matt Mullenweg to learn about where WordPress is going and how you can get involved.</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:group {"layout":{"type":"flex"}} -->
+			<div class="wp-block-group">
+				<!-- wp:social-links {"iconColor":"blue-1","iconColorValue":"#3e58e1","className":"is-style-logos-only"} -->
+				<ul class="wp-block-social-links has-icon-color is-style-logos-only">
+					<!-- wp:social-link {"url":"https://podcasts.apple.com/us/podcast/wp-briefing/id1551691710","service":"chain","label":"Apple Podcasts","className":"wp-briefing__apple-podcasts"} /-->
+					<!-- wp:social-link {"url":"https://podcasts.google.com/feed/aHR0cHM6Ly93b3JkcHJlc3Mub3JnL25ld3MvZmVlZC9wb2RjYXN0","service":"chain","label":"Google Podcasts","className":"wp-briefing__google-podcasts"} /-->
+					<!-- wp:social-link {"url":"https://pca.st/uqvvmt8t","service":"chain","label":"Pocket Casts","className":"wp-briefing__pocket-casts"} /-->
+					<!-- wp:social-link {"url":"https://wordpress.org/news/feed/podcast","service":"feed","label":"RSS"} /-->
+					<!-- wp:social-link {"url":"https://open.spotify.com/show/6BxgmE9Qg2TZA8EKZLJ4zS","service":"spotify","label":"Spotify"} /-->
+					<!-- wp:social-link {"url":"https://www.stitcher.com/show/wp-briefing","service":"chain","label":"Stitcher","className":"wp-briefing__stitcher"} /-->
+				</ul>
+				<!-- /wp:social-links -->
+
+				<!-- wp:paragraph {"className":"podcast-link"} -->
+				<p class="podcast-link"><a href="https://wordpress.org/news/podcast/">Listen to all episodes</a></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
@@ -1,41 +1,47 @@
 // Default/light version.
-.footer-archive .footer-archive-row[class*="wp-container-"] {
-	justify-content: space-between;
-	align-items: stretch !important;
-	margin-top: 0;
-	gap: 0;
-	background-color: var(--wp--preset--color--white);
-	line-height: 30px;
-
-	h3 {
-		margin-bottom: var(--wp--custom--margin--baseline);
+.footer-archive {
+	h2 {
+		display: none;
 	}
-
-	h3 + p {
+	
+	.footer-archive-row[class*="wp-container-"] {
+		justify-content: space-between;
+		align-items: stretch !important;
 		margin-top: 0;
-	}
+		gap: 0;
+		background-color: var(--wp--preset--color--white);
+		line-height: 30px;
 
-	& > * {
-		padding-top: 50px;
-		padding-bottom: 50px;
-		border-bottom: 1px solid var(--wp--preset--color--light-grey);
+		h3 {
+			margin-bottom: var(--wp--custom--margin--baseline);
+		}
 
-		@include break-medium {
-			flex-basis: 50%;
-			flex-shrink: 0;
-			flex-grow: 0;
-			padding-top: 60px;
-			padding-bottom: 60px;
-			border-top: 1px solid var(--wp--preset--color--light-grey);
-			border-bottom: none;
+		h3 + p {
+			margin-top: 0;
+		}
 
-			&:nth-child(odd) {
-				border-right: 1px solid var(--wp--preset--color--light-grey);
-				padding-right: var( --wp--custom--alignment--edge-spacing );
-			}
+		& > * {
+			padding-top: 50px;
+			padding-bottom: 50px;
+			border-bottom: 1px solid var(--wp--preset--color--light-grey);
 
-			&:nth-child(even) {
-				padding-left: var( --wp--custom--alignment--edge-spacing );
+			@include break-medium {
+				flex-basis: 50%;
+				flex-shrink: 0;
+				flex-grow: 0;
+				padding-top: 60px;
+				padding-bottom: 60px;
+				border-top: 1px solid var(--wp--preset--color--light-grey);
+				border-bottom: none;
+
+				&:nth-child(odd) {
+					border-right: 1px solid var(--wp--preset--color--light-grey);
+					padding-right: var( --wp--custom--alignment--edge-spacing );
+				}
+
+				&:nth-child(even) {
+					padding-left: var( --wp--custom--alignment--edge-spacing );
+				}
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
@@ -13,6 +13,7 @@
 		line-height: 30px;
 
 		h3 {
+			font-size: 26px;
 			margin-bottom: var(--wp--custom--margin--baseline);
 		}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
@@ -7,11 +7,11 @@
 	background-color: var(--wp--preset--color--white);
 	line-height: 30px;
 
-	h5 {
+	h3 {
 		margin-bottom: var(--wp--custom--margin--baseline);
 	}
 
-	h5 + p {
+	h3 + p {
 		margin-top: 0;
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
@@ -7,6 +7,14 @@
 	background-color: var(--wp--preset--color--white);
 	line-height: 30px;
 
+	h5 {
+		margin-bottom: var(--wp--custom--margin--baseline);
+	}
+
+	h5 + p {
+		margin-top: 0;
+	}
+
 	& > * {
 		padding-top: 50px;
 		padding-bottom: 50px;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
@@ -5,6 +5,7 @@
 	margin-top: 0;
 	gap: 0;
 	background-color: var(--wp--preset--color--white);
+	line-height: 30px;
 
 	& > * {
 		padding-top: 50px;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
@@ -1,48 +1,42 @@
-// Default/light version.
-.footer-archive {
-	h2 {
-		display: none;
+// Default/light version.	
+.footer-archive-row[class*="wp-container-"] {
+	justify-content: space-between;
+	align-items: stretch !important;
+	margin-top: 0;
+	gap: 0;
+	background-color: var(--wp--preset--color--white);
+	line-height: 30px;
+
+	h3 {
+		font-size: 26px;
+		margin-bottom: var(--wp--custom--margin--baseline);
 	}
-	
-	.footer-archive-row[class*="wp-container-"] {
-		justify-content: space-between;
-		align-items: stretch !important;
+
+	h3 + p {
 		margin-top: 0;
-		gap: 0;
-		background-color: var(--wp--preset--color--white);
-		line-height: 30px;
+	}
 
-		h3 {
-			font-size: 26px;
-			margin-bottom: var(--wp--custom--margin--baseline);
-		}
+	& > * {
+		padding-top: 50px;
+		padding-bottom: 50px;
+		border-bottom: 1px solid var(--wp--preset--color--light-grey);
 
-		h3 + p {
-			margin-top: 0;
-		}
+		@include break-medium {
+			flex-basis: 50%;
+			flex-shrink: 0;
+			flex-grow: 0;
+			padding-top: 60px;
+			padding-bottom: 60px;
+			border-top: 1px solid var(--wp--preset--color--light-grey);
+			border-bottom: none;
 
-		& > * {
-			padding-top: 50px;
-			padding-bottom: 50px;
-			border-bottom: 1px solid var(--wp--preset--color--light-grey);
+			&:nth-child(odd) {
+				border-right: 1px solid var(--wp--preset--color--light-grey);
+				padding-right: var( --wp--custom--alignment--edge-spacing );
+			}
 
-			@include break-medium {
-				flex-basis: 50%;
-				flex-shrink: 0;
-				flex-grow: 0;
-				padding-top: 60px;
-				padding-bottom: 60px;
-				border-top: 1px solid var(--wp--preset--color--light-grey);
-				border-bottom: none;
-
-				&:nth-child(odd) {
-					border-right: 1px solid var(--wp--preset--color--light-grey);
-					padding-right: var( --wp--custom--alignment--edge-spacing );
-				}
-
-				&:nth-child(even) {
-					padding-left: var( --wp--custom--alignment--edge-spacing );
-				}
+			&:nth-child(even) {
+				padding-left: var( --wp--custom--alignment--edge-spacing );
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_wp-briefing.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_wp-briefing.scss
@@ -6,8 +6,7 @@
 
 	.podcast-link {
 		line-height: 2.4;
-		margin-top: 1.1em;
-		padding: 0 1em 1.1em;
+		padding: 1em 1em 1em 0;
 		background-image: url("images/brush-stroke-short-2-blue-4.svg");
 		background-position: bottom right;
 		background-repeat: no-repeat;

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -298,7 +298,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "20px",
+					"fontSize": "26px",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -265,7 +265,7 @@
 				"breakpoint": {
 					"mobile": {
 						"typography": {
-							"fontSize": "36px",
+							"fontSize": "clamp(26px, 4vw, 36px)",
 							"lineHeight": "1.35"
 						}
 					}
@@ -298,7 +298,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "26px",
+					"fontSize": "20px",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},


### PR DESCRIPTION
This PR adds a few tweaks to enhance the bottom banner:

- Refactor the podcast link spacing so the 'Listen to all episodes' link sits to the left at small resolutions
- Increases the line height of the bottom banner in line with design in Figma
- Adds spacing below headings in line with Figma
- Increases font size of headings at mobile in line with Figma

| Before | After |
| ------- | -------- |
| ![image](https://user-images.githubusercontent.com/1645628/145079961-ab5b86f7-2015-4240-bbba-4986e0ad0533.png) | ![image](https://user-images.githubusercontent.com/1645628/145079817-a6245b54-6be1-4160-9d04-408b7ec647f8.png) |