### PR TITLE
Fixing "People of WordPress" section layout to match design

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -5,7 +5,7 @@
 	<!-- /wp:heading -->
 
 	<!-- wp:post-template {"align":"full"} -->
-		<!-- wp:post-featured-image {"width":"265px","height":"265px","scale":"cover","isLink":true} /-->
+		<!-- wp:post-featured-image {"isLink":true} /-->
 
 		<!-- wp:post-title {"level":3,"isLink":true} /-->
 	<!-- /wp:post-template -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -1,4 +1,4 @@
-<!-- wp:query {"query":{"perPage":5,"categoryIds":[25]},"tagName":"section","className":"front__people-of-wordpress","align":"full"} -->
+<!-- wp:query {"query":{"perPage":5,"postType":"post","tagIds":[14]},"tagName":"section","className":"front__people-of-wordpress","align":"full"} -->
 <section class="front__people-of-wordpress alignfull">
 	<!-- wp:heading {"level":2} -->
 	<h2>People of WordPress</h2>

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_people-of-wordpress.scss
@@ -22,26 +22,29 @@ body.news-front-page .front__people-of-wordpress {
 
 	ul.wp-block-post-template {
 		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
-		justify-content: space-between;
-		gap: 0;
+		flex-direction: column;
 		margin: 0;
 
 		@include break-medium() {
+			flex-direction: row;
 			grid-area: thumbnails;
+			gap: 2px;
 		}
 
 		li {
-			flex-basis: 200px;
-			flex-grow: 1;
+			flex-basis: 100%;
 			margin-top: 0;
+
+			@include break-small() {
+				flex-basis: 20%;
+			}
 
 			.wp-block-post-featured-image {
 				margin: 0;
-
 				img {
 					filter: grayscale(100%);
+					aspect-ratio: 1 / 1;
+					object-fit: cover;
 
 					&:hover {
 						filter: grayscale(0%);


### PR DESCRIPTION
## Description
- Fix "People of WordPress" section layout to match design
- Update template part to query posts by tag instead of by category

## Screenshots
- Before (mobile)
![image](https://user-images.githubusercontent.com/1310626/145090021-c95d93d9-c638-4502-97ba-71f275994544.png)


- After (mobile)
![image](https://user-images.githubusercontent.com/1310626/145090054-32e9cac9-3120-41ab-a581-f990e237fd58.png)


- Before (desktop)
![image](https://user-images.githubusercontent.com/1310626/145090069-3e8d2af9-1899-4daf-9466-64ebfd790baa.png)


- After (desktop)
![image](https://user-images.githubusercontent.com/1310626/145090075-7f3522dd-7290-4120-a14f-f2c339b5ed0c.png)
