### PR TITLE
Local Header: Match arrow stroke to current text color

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -106,6 +106,7 @@
 
 			svg {
 				vertical-align: middle;
+				stroke: currentColor;
 			}
 		}
 


### PR DESCRIPTION
The background and text color can change on the Categories dropdown toggle, but the SVG arrow did not inherit the change, making it either mismatched or invisible on some categories. This uses the `currentColor` keyword to match the stroke to the current text color.

| Before | After |
|--------|------|
| ![before-home](https://user-images.githubusercontent.com/541093/145113946-d3cf2133-ea3b-413e-a8f2-de91314f2850.png) | ![after-home](https://user-images.githubusercontent.com/541093/145113945-b36f8998-d514-4ced-aca9-1ff6ede72184.png) |
| ![before-dev](https://user-images.githubusercontent.com/541093/145113818-96a3fc65-8826-4516-8643-f4273f0b8943.png) | ![after-dev](https://user-images.githubusercontent.com/541093/145113812-91d81d50-bdd5-4574-b272-bc4bb889378d.png) |
| ![before-events](https://user-images.githubusercontent.com/541093/145113819-c7e4a7b7-55f9-4b37-9a2c-d524d90d956e.png) | ![after-events](https://user-images.githubusercontent.com/541093/145113813-0c665d34-69ee-44f3-95eb-8214ce3ab88c.png) |
| ![before-sec](https://user-images.githubusercontent.com/541093/145113824-4bc7a91a-9170-4296-9237-63f97cfa48b7.png) | ![after-sec](https://user-images.githubusercontent.com/541093/145113816-df59ef92-f68b-46ab-a9db-15ca04f52ece.png) |
| ![before-miwp](https://user-images.githubusercontent.com/541093/145113821-32b866fc-770b-483b-8eeb-ba409db40ff0.png) | ![after-miwp](https://user-images.githubusercontent.com/541093/145113814-b3391bbb-9c67-4c1d-9c8a-9827a579ff33.png) |



