### PR TITLE
Add a hasThumbnail pseudo-attribute to the wp:query block

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -1,4 +1,4 @@
-<!-- wp:query {"query":{"perPage":5,"categoryIds":[25]},"tagName":"section","className":"front__people-of-wordpress","align":"full"} -->
+<!-- wp:query {"query":{"perPage":5,"categoryIds":[25],"hasThumbnail":true},"tagName":"section","className":"front__people-of-wordpress","align":"full"} -->
 <section class="front__people-of-wordpress alignfull">
 	<!-- wp:heading {"level":2} -->
 	<h2>People of WordPress</h2>


### PR DESCRIPTION
This lets us use `wp:query {"query":{"hasThumbnail":true}}` to query only for posts with a featured image/thumbnail.

I'm in two minds about the method of doing this; what do you think?