### PR TITLE
Local Navigation: Style dropdown to match design

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -16,19 +16,17 @@
 
 	&__navigation {
 		position: relative;
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		flex-direction: column;
 
 		@include break-mobile {
-			display: flex;
-			align-items: flex-start;
-			justify-content: space-between;
+			flex-direction: row;
 		}
 
 		[class*="wp-container-"] & {
-			padding: 15px 0.5em;
-
-			@include break-mobile {
-				padding: 0 0.5em;
-			}
+			padding: 0 0.5em;
 
 			@include break-xlarge {
 				padding: 0;
@@ -38,10 +36,7 @@
 
 	&__breadcrumb {
 		color: var(--bar-text-color);
-
-		@include break-mobile {
-			line-height: 50px;
-		}
+		line-height: 50px;
 
 		&-current {
 			display: none;
@@ -74,9 +69,14 @@
 
 	&__categories {
 		--flex-items-per-column: 8;
+		width: 100%;
 
-		/* The scrollbar covers up part of the edge padding, so this offsets that. */
-		padding-right: var(--wp--custom--alignment--scroll-bar-width);
+		@include break-mobile {
+
+			/* The scrollbar covers up part of the edge padding, so this offsets that. */
+			padding-right: var(--wp--custom--alignment--scroll-bar-width);
+			width: auto;
+		}
 
 		@include break-medium {
 			--flex-items-per-column: 4;
@@ -93,6 +93,7 @@
 			margin: 0;
 			padding: 15px 0;
 			cursor: pointer;
+			text-align: right;
 
 			@include break-mobile {
 				line-height: 50px;
@@ -165,35 +166,54 @@
 		.wp-block-categories {
 			display: none;
 			opacity: 0;
+			position: relative;
+			right: calc(var(--wp--custom--alignment--edge-spacing) * -1);
 			flex-direction: column;
 			flex-wrap: wrap;
 			width: calc(min(100%, var(--wp--custom--layout--wide-size)));
 			color: var(--bar-text-color);
 			list-style: none;
 			padding: 0 0 2em 0;
+			text-align: right;
 
 			@include break-mobile {
 				padding: 0 var(--wp--custom--alignment--edge-spacing);
 				position: absolute;
 				left: 0;
+				right: auto;
 				top: 75px;
 				max-height: calc(1rem * var(--wp--custom--body--typography--line-height) * var(--flex-items-per-column));
+				text-align: left;
 			}
 
 			[class*="wp-container-"] & {
 				margin-top: 0;
 			}
 
-			a {
-				color: var(--bar-link-color);
+			li {
+				padding: 0.25em calc(var(--wp--custom--alignment--edge-spacing) - 4px) 0.25em 0;
+				border-right: 4px solid transparent;
+
+				@include break-mobile {
+					padding: 0.25em 0;
+				}
 			}
 
 			.current-cat {
 				font-weight: 700;
+				border-right-color: currentColor;
 
-				&::before {
-					content: "\0020\00B7\0020";
+				@include break-mobile {
+					border: none;
+
+					&::before {
+						content: "\0020\00B7\0020";
+					}
 				}
+			}
+
+			a {
+				color: var(--bar-link-color);
 			}
 		}
 	}


### PR DESCRIPTION
This updates the local category nav to match the figma design on small screens. Specifically, it adds more space around the header, and right-aligns the category label & menu items, and adds the different current indicator. The only change to the desktop-sized menu is a slight increase in padding on the categories.

Fixes #86 (along with https://github.com/WordPress/wporg-mu-plugins/pull/30)

| Before | After |
|--------|-------|
| ![before-large-closed](https://user-images.githubusercontent.com/541093/145285737-75f42794-c8f1-4973-b42d-3843d1101470.png) | ![after-large-closed](https://user-images.githubusercontent.com/541093/145285726-7cb6e4ce-892f-494a-b383-5a0888f1eb3b.png) |
| ![before-large-open](https://user-images.githubusercontent.com/541093/145285738-377511e5-39f5-4cbc-9b8a-6abd6bcd1137.png) | ![after-large-open](https://user-images.githubusercontent.com/541093/145285731-9219a3cf-f2b2-41d9-9ac9-01849c72a92c.png) |
| ![before-small-closed](https://user-images.githubusercontent.com/541093/145285740-311ee7c0-db69-49dc-95cc-35ff068e9e82.png) | ![after-small-closed](https://user-images.githubusercontent.com/541093/145285734-001b4219-5d96-4321-8671-27e5cf4112c8.png) |
| ![before-small-open](https://user-images.githubusercontent.com/541093/145285741-7f06f80c-1a1e-44a5-ab6e-735d47efac63.png) | ![after-small-open](https://user-images.githubusercontent.com/541093/145285735-f4b6218c-4a49-4678-a748-08a5610334ad.png) |


