### PR TITLE
Latest Release: Update style to match design

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -20,6 +20,7 @@ add_filter( 'post_class', __NAMESPACE__ . '\specify_post_classes', 10, 3 );
 add_filter( 'theme_file_path', __NAMESPACE__ . '\conditional_template_part', 10, 2 );
 add_filter( 'render_block_data', __NAMESPACE__ . '\custom_query_block_attributes' );
 add_filter( 'template_redirect', __NAMESPACE__ . '\jetpack_likes_workaround' );
+add_filter( 'the_title', __NAMESPACE__ . '\update_the_title', 10, 2 );
 
 /**
  * Register theme support.
@@ -348,4 +349,21 @@ function jetpack_likes_workaround() {
 	if ( is_callable( [ $jetpack_likes, 'load_styles_register_scripts' ] ) ) {
 		$jetpack_likes->load_styles_register_scripts();
 	}
+}
+
+/**
+ * Remove "WordPress" from the release post title.
+ *
+ * @param string $title The post title.
+ * @param int    $id    The post ID.
+ * @return string Filtered post title.
+ */
+function update_the_title( $title, $id ) {
+	// Remove "WordPress" from the post title in the Latest Release section on the front page.
+	$category_slugs = wp_list_pluck( get_the_category( $id ), 'slug' );
+	if ( is_front_page() && in_array( 'releases', $category_slugs ) ) {
+		return str_replace( 'WordPress', '', $title );
+	}
+
+	return $title;
 }

--- a/source/wp-content/themes/wporg-news-2021/images/right-arrow.svg
+++ b/source/wp-content/themes/wporg-news-2021/images/right-arrow.svg
@@ -1,4 +1,4 @@
 <svg width="101" height="100" viewBox="0 0 101 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<path d="M22 50L97 50" stroke="white" stroke-width="1.5" />
+	<path d="M0 50L97 50" stroke="white" stroke-width="1.5" />
 	<path d="M49.8545 0.718018L98.9491 49.8126L49.8545 98.9072" stroke="white" stroke-width="1.5" />
 </svg>

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_latest-release.scss
@@ -19,7 +19,7 @@ body.news-front-page .front__latest-release {
 
 	.wp-block-post-template {
 		.wp-block-post-title {
-			--header-size: clamp(var(--wp--preset--font-size--huge), 8vw, 130px);
+			--header-size: clamp(var(--wp--preset--font-size--huge), 13vw, 130px);
 
 			margin-bottom: var(--wp--custom--margin--vertical);
 			padding-right: var(--header-size);

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_latest-release.scss
@@ -21,20 +21,15 @@ body.news-front-page .front__latest-release {
 		.wp-block-post-title {
 			--header-size: clamp(var(--wp--preset--font-size--huge), 8vw, 130px);
 
+			margin-bottom: var(--wp--custom--margin--vertical);
+			padding-right: var(--header-size);
+			background-image: url(images/right-arrow.svg);
+			background-size: var(--header-size);
+			background-repeat: no-repeat;
+			background-position: right center;
 			font-size: var(--header-size);
-
-			a::after {
-
-				/* The empty content is necessary for the pseudo-element to exist in the DOM. */
-				display: inline-block;
-				content: "";
-				background-image: url(images/right-arrow.svg);
-				background-size: 75% 75%;
-				background-repeat: no-repeat;
-				background-position: left bottom;
-				width: var(--header-size);
-				height: var(--header-size);
-			}
+			font-family: var(--wp--preset--font-family--inter);
+			font-weight: 200;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -434,7 +434,7 @@
 					"fontFamily": "'Inter', sans-serif",
 					"slug": "inter",
 					"name": "Inter",
-					"google": "family=Inter:wght@400;700"
+					"google": "family=Inter:wght@200..700"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
Fixes #114 — Updated the font, spacing, and removed "WordPress" from this post title.

<img width="639" alt="Screen Shot 2021-12-09 at 4 49 55 PM" src="https://user-images.githubusercontent.com/541093/145481340-c562bd11-353d-4de5-8244-7f443abae74e.png">
<img width="1319" alt="Screen Shot 2021-12-09 at 4 48 19 PM" src="https://user-images.githubusercontent.com/541093/145481343-30729717-b799-4b64-b045-372186fcbade.png">
