### PR TITLE
Homepage improvements

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -8,7 +8,7 @@
 	<!-- wp:post-template -->
 		<!-- wp:group {"tagName":"header","className":"entry-header"} -->
 		<header class="wp-block-group entry-header">
-			<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"20px"}}}} /-->
+			<!-- wp:post-title {"level":3,"isLink":true} /-->
 
 			<!-- wp:group {"className":"entry-meta","style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)","lineHeight":"1.6"}}} -->
 			<div class="wp-block-group entry-meta" style="font-size:var(--wp--preset--font-size--small);line-height:1.6;">

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -8,10 +8,10 @@
 	<!-- wp:post-template -->
 		<!-- wp:group {"tagName":"header","className":"entry-header"} -->
 		<header class="wp-block-group entry-header">
-			<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"30px"}}}} /-->
+			<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"20px"}}}} /-->
 
-			<!-- wp:group {"className":"entry-meta","style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} -->
-			<div class="wp-block-group entry-meta" style="font-size:var(--wp--preset--font-size--small);">
+			<!-- wp:group {"className":"entry-meta","style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)","lineHeight":"1.6"}}} -->
+			<div class="wp-block-group entry-meta" style="font-size:var(--wp--preset--font-size--small);line-height:1.6;">
 				<!-- wp:post-terms {"term":"category"} /-->
 				<!-- wp:post-date /-->
 			</div>

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -10,8 +10,8 @@
 		<header class="wp-block-group entry-header">
 			<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"30px"}}}} /-->
 
-			<!-- wp:group {"className":"entry-meta"} -->
-			<div class="wp-block-group entry-meta">
+			<!-- wp:group {"className":"entry-meta","style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} -->
+			<div class="wp-block-group entry-meta" style="font-size:var(--wp--preset--font-size--small);">
 				<!-- wp:post-terms {"term":"category"} /-->
 				<!-- wp:post-date /-->
 			</div>

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -8,7 +8,7 @@
 	<!-- wp:post-template -->
 		<!-- wp:group {"tagName":"header","className":"entry-header"} -->
 		<header class="wp-block-group entry-header">
-			<!-- wp:post-title {"level":3,"isLink":true} /-->
+			<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"30px"}}}} /-->
 
 			<!-- wp:group {"className":"entry-meta"} -->
 			<div class="wp-block-group entry-meta">

--- a/source/wp-content/themes/wporg-news-2021/sass/base/_alignment.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_alignment.scss
@@ -10,7 +10,7 @@
 
 //FRONTEND
 // The global header and global footer are excluded here because they set their own styles.
-.wp-site-blocks > *:not(.site-header-container):not(.global-footer),
+.wp-site-blocks > *:not(.site-header-container):not(.global-footer):not(.footer-archive),
 .wp-site-blocks .local-header {
 	// In this situation we want to introduce a standardized gap between content and the edge of the screen.
 	@extend %edge-spacing-padding;

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
@@ -8,22 +8,22 @@
 	color: var(--wp--preset--color--blue-1);
 	position: relative;
 
+	.wp-block-query-pagination-next {
+		z-index: 2;
+	}
+
 	&::after {
 		content: "";
 		position: absolute;
 		top: 0;
-		bottom: 0;
+		bottom: 50px;
 		right: 0;
-		left: 0;
+		left: -50px;
 		background-color: var(--wp--preset--color--off-white-2);
 		mask-image: url(images/brush-stroke-short-blue-4.svg);
-		mask-position: center;
+		mask-position: bottom left;
 		mask-repeat: no-repeat;
 		mask-size: contain;
-	}
-
-	a {
-		position: relative;
 		z-index: 1;
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
@@ -16,15 +16,20 @@
 		content: "";
 		position: absolute;
 		top: 0;
-		bottom: 50px;
+		bottom: 0;
 		right: 0;
-		left: -50px;
+		left: 0;
 		background-color: var(--wp--preset--color--off-white-2);
 		mask-image: url(images/brush-stroke-short-blue-4.svg);
 		mask-position: bottom left;
 		mask-repeat: no-repeat;
 		mask-size: contain;
 		z-index: 1;
+
+		@include break-wide() {
+			bottom: 50px;
+			left: -50px;
+		}
 	}
 
 	> .wp-block-query-pagination-previous,

--- a/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_subscribe-wp-news.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_subscribe-wp-news.scss
@@ -22,7 +22,6 @@
 
 				input {
 					width: 100%;
-					height: 42px;
 					border: 1px solid var(--wp--preset--color--black);
 					border-radius: 2px 0 0 2px;
 				}
@@ -32,8 +31,8 @@
 				grid-area: submit;
 
 				.wp-block-button__link {
-					height: 42px;
 					border-radius: 0 2px 2px 0;
+					line-height: 1.8;
 				}
 			}
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
@@ -27,6 +27,10 @@
 			padding-top: var(--wp--custom--alignment--edge-spacing);
 			padding-bottom: var(--wp--custom--alignment--edge-spacing);
 		}
+
+		> .wp-block-post:not(:first-of-type) {
+			margin-top: 75px;
+		}
 	}
 
 	> .wp-block-query-pagination {

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
@@ -29,7 +29,7 @@
 		}
 
 		> .wp-block-post:not(:first-of-type) {
-			margin-top: 75px;
+			margin-top: 58px;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
@@ -114,13 +114,13 @@ body.news-front-page {
 			border-top: none;
 		}
 
-		.footer-archive-row:first-of-type,
-		.footer-archive-row:nth-child(3) {
+		.footer-archive-row:first-of-type > *,
+		.footer-archive-row:nth-child(3) > * {
 			padding-left: var(--wp--custom--alignment--edge-spacing);
 		}
 
-		.footer-archive-row:last-of-type,
-		.footer-archive-row:nth-child(2) {
+		.footer-archive-row:last-of-type > *,
+		.footer-archive-row:nth-child(2) > * {
 			padding-right: var(--wp--custom--alignment--edge-spacing);
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
@@ -101,5 +101,15 @@ body.news-front-page {
 		.footer-archive-row:first-of-type > * {
 			border-top: none;
 		}
+
+		.footer-archive-row:first-of-type,
+		.footer-archive-row:nth-child(3) {
+			padding-left: var(--wp--custom--alignment--edge-spacing);
+		}
+
+		.footer-archive-row:last-of-type,
+		.footer-archive-row:nth-child(2) {
+			padding-right: var(--wp--custom--alignment--edge-spacing);
+		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
@@ -28,8 +28,20 @@
 			padding-bottom: var(--wp--custom--alignment--edge-spacing);
 		}
 
-		> .wp-block-post:not(:first-of-type) {
-			margin-top: 58px;
+		> .wp-block-post:not(:last-of-type) {
+			margin-bottom: 45px;
+
+			@include break-wide() {
+				margin-bottom: 58px;
+			}
+		}
+
+		.wp-block-post-title {
+			margin-bottom: 12px;
+
+			@include break-wide() {
+				margin-bottom: 20px;
+			}
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -266,7 +266,7 @@
 					"mobile": {
 						"typography": {
 							"fontSize": "clamp(26px, 4vw, 36px)",
-							"lineHeight": "1.35"
+							"lineHeight": "1.3"
 						}
 					}
 				},

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -257,7 +257,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "30px",
+					"fontSize": "26px",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},


### PR DESCRIPTION
This PR addresses a couple of issues from #121:

- Post titles should be `50px` at desktop and `26px` at mobile
- There should be `50px` visual spacing below the titles at desktop, and `20px` at mobile
- There should be about `75px` visual spacing above the titles at desktop, and `50px` at mobile
   - This includes spacing caused by `line-height` of the surrounding elements. I tried to match the above and below spacing to Figma as closely as possible.
- Post date and post meta are now `14px` font size
   - I haven't made them `13px` at mobile as Gutenberg doesn't allow for different font sizes at different breakpoints as far as I know, and as it's only `1px` difference I left it. We can override this with CSS if it's important.
- Stroke shape is now more accurately behind “See All Posts”
   - The image isn't relative to the link text, so it's possible that it may not sit behind the text if the height of the container changes due to the 'latest posts' content. These changes make it closer than before without re-working this part of the design.
- Subscribe button and placeholder should now be better aligned
- The lines in the 'footer archive' section now go all the way to the left and right edges

Things I couldn't replicate:
- The People of WordPress photos are square for me on both the test site and locally so I didn't change anything here. Was there a problem with this in a particular browser?
- The line height of the links in the footer is `24.7px` on both the test site and in Figma. Should we still reduce this? It does look visually smaller on Figma compared to the site..

Desktop:

| Before | After |
| -------| ------ |
|  ![localhost_8888_](https://user-images.githubusercontent.com/1645628/145616401-9d8395b7-f045-4f69-b15b-0afeae4d8ffe.png)   |   ![localhost_8888_ (2)](https://user-images.githubusercontent.com/1645628/145616311-a79c3e0d-975e-4511-b0f8-81302fc0e6cb.png)  |

Mobile:

| Before | After |
| -------| ------ |
| ![localhost_8888_](https://user-images.githubusercontent.com/1645628/145619048-d00e468d-e2a7-4622-a1bb-1f5de0e0ea85.png)  |  ![localhost_8888_](https://user-images.githubusercontent.com/1645628/145618988-6d1d18a6-0792-4271-9996-7ee8dea76e5a.png)   |

Subscribe:

| Before | After |
| -------| ------ |
| ![image](https://user-images.githubusercontent.com/1645628/145619186-31f8d95a-651c-4cf0-bc7e-ade5ea67742e.png)  |   ![image](https://user-images.githubusercontent.com/1645628/145619311-b2faeaf9-b9b9-44fa-ab98-fe29525b471d.png) |