### PR TITLE
Update styles on single post view

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/post-navigation.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/post-navigation.html
@@ -3,6 +3,6 @@
 <!-- /wp:separator -->
 
 <nav class="post-navigation">
-	<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"label":"Previous"} /-->
-	<!-- wp:post-navigation-link {"type":"next","showTitle":true,"label":"Next"} /-->
+	<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"label":"Previous","linkLabel":true} /-->
+	<!-- wp:post-navigation-link {"type":"next","showTitle":true,"label":"Next","linkLabel":true} /-->
 </nav>

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_gallery.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_gallery.scss
@@ -1,8 +1,0 @@
-.wp-block-gallery {
-	.blocks-gallery-image,
-	.blocks-gallery-item {
-		figcaption {
-			font-size: var(--wp--custom--gallery--caption--font-size);
-		}
-	}
-}

--- a/source/wp-content/themes/wporg-news-2021/sass/elements/_captions.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/elements/_captions.scss
@@ -1,0 +1,9 @@
+.wp-block-gallery.wp-block-gallery, // Double class for increased specificity.
+[class*="wp-block-"] {
+	figcaption {
+		font-size: var(--wp--custom--gallery--caption--font-size);
+		text-align: right;
+		padding-left: var(--wp--style--block-gap);
+		padding-right: var(--wp--style--block-gap);
+	}
+}

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -3,8 +3,13 @@
 
 	.wp-block-gallery,
 	.wp-block-image {
-		margin-top: 70px;
-		margin-bottom: 70px;
+		margin-top: 40px;
+		margin-bottom: 40px;
+
+		@include break-mobile() {
+			margin-top: 70px;
+			margin-bottom: 70px;
+		}
 	}
 }
 

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -4,11 +4,15 @@
 	.wp-block-gallery,
 	.wp-block-image {
 		margin-top: 40px;
-		margin-bottom: 40px;
+		margin-bottom: 16px;
 
 		@include break-mobile() {
 			margin-top: 70px;
-			margin-bottom: 70px;
+			margin-bottom: 46px;
+		}
+
+		&:first-child {
+			margin-top: 0;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -1,5 +1,11 @@
 .wp-block-post-content {
 	padding-bottom: var(--wp--style--block-gap);
+
+	.wp-block-gallery,
+	.wp-block-image {
+		margin-top: 70px;
+		margin-bottom: 70px;
+	}
 }
 
 body.news-posts-index .site-content-container,

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
@@ -60,6 +60,15 @@
 
 	.entry-meta {
 		margin-bottom: 25px;
+		font-size: 13px;
+
+		* {
+			font-size: inherit;
+		}
+
+		@include break-mobile() {
+			font-size: var(--wp--preset--font-size--small);
+		}
 
 		@include break-wide() {
 			grid-area: entry-meta;

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
@@ -22,13 +22,24 @@
 
 	.single &,
 	.page & {
+		margin-top: 20px;
+
+		@include break-mobile() {
+			margin-top: 32px;
+		}
+
 		.wp-block-post-date {
-			margin: calc(var(--wp--custom--margin--vertical) / 2) 0;
+			margin: calc(var(--wp--custom--margin--vertical) / 2) 0 0;
 		}
 
 		.wp-block-post-author,
 		.wp-block-post-terms {
 			display: inline-block;
+		}
+
+		+ .wp-block-separator {
+			margin-top: 70px;
+			margin-bottom: 70px;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
@@ -22,14 +22,14 @@
 
 	.single &,
 	.page & {
-		margin-top: 20px;
+		margin-top: 8px;
 
 		@include break-mobile() {
 			margin-top: 32px;
-		}
 
-		.wp-block-post-date {
-			margin: calc(var(--wp--custom--margin--vertical) / 2) 0 0;
+			.wp-block-post-date {
+				margin: calc(var(--wp--custom--margin--vertical) / 2) 0 0;
+			}
 		}
 
 		.wp-block-post-author,
@@ -38,8 +38,13 @@
 		}
 
 		+ .wp-block-separator {
-			margin-top: 70px;
-			margin-bottom: 70px;
+			margin-top: 40px;
+			margin-bottom: 40px;
+
+			@include break-mobile() {
+				margin-top: 70px;
+				margin-bottom: 70px;
+			}
 		}
 	}
 }
@@ -54,10 +59,11 @@
 	}
 
 	.entry-meta {
-		font-size: var(--wp--preset--font-size--small);
+		margin-bottom: 25px;
 
 		@include break-wide() {
 			grid-area: entry-meta;
+			margin-bottom: 0;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
@@ -5,12 +5,14 @@
 	gap: calc(var(--wp--style--block-gap) * 2);
 
 	.wp-block-post-navigation-link {
-		display: flex;
-		flex-direction: column;
+		a {
+			display: flex;
+			flex-direction: column;
 
-		@include break-medium() {
-			gap: 1ch;
-			flex-direction: row;
+			@include break-medium() {
+				gap: 1ch;
+				flex-direction: row;
+			}
 		}
 
 		&.post-navigation-link-previous {
@@ -19,7 +21,7 @@
 			}
 
 			@include break-medium() {
-				span::after {
+				.post-navigation-link__label::after {
 					content: " \00B7\0020";
 				}
 			}
@@ -29,13 +31,23 @@
 			text-align: end;
 
 			@include break-medium() {
-				flex-direction: row-reverse;
+				a {
+					flex-direction: row-reverse;
+				}
 
-				span::before {
+				.post-navigation-link__label::before {
 					content: " \0020\00B7";
 					padding-right: 0.3em;
 				}
 			}
+		}
+	}
+
+	.post-navigation-link__title {
+
+		@media (max-width: #{ ($break-medium - 1) }) {
+
+			@include hide-accessibly;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
@@ -7,7 +7,7 @@
 	.wp-block-post-navigation-link {
 		display: flex;
 		flex-direction: column;
-		
+
 		@include break-medium() {
 			gap: 1ch;
 			flex-direction: row;
@@ -30,6 +30,7 @@
 
 			@include break-medium() {
 				flex-direction: row-reverse;
+
 				span::before {
 					content: " \0020\00B7";
 					padding-right: 0.3em;

--- a/source/wp-content/themes/wporg-news-2021/sass/style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/style.scss
@@ -40,13 +40,13 @@ GNU General Public License for more details.
 @import "elements/headings";
 @import "elements/links";
 @import "elements/lists";
+@import "elements/captions";
 
 
 // Blocks
 // Override the default styles that a block has from Core, it's plugin, etc.
 @import "blocks/button";
 @import "blocks/code";
-@import "blocks/gallery";
 @import "blocks/html";
 @import "blocks/image";
 @import "blocks/latest-posts";


### PR DESCRIPTION
See #122 — this addresses everything but the quote, which I'll do in another PR.

| Before | After |
|--------|------|
| ![before-large-post](https://user-images.githubusercontent.com/541093/145640510-947214fa-8bad-4dda-a823-e0b02af09448.png) | ![after-large-post](https://user-images.githubusercontent.com/541093/145640502-78eef9b4-286a-475b-9604-410831495e61.png) |
| ![before-small-post](https://user-images.githubusercontent.com/541093/145640514-d465fd9f-f324-4342-a45a-7ce02f65ba84.png) | ![after-small-post](https://user-images.githubusercontent.com/541093/145640507-35fbfdb3-b8c6-4372-b0cf-cdc4bbc543f2.png) |
| <img width="513" alt="before-small-post-nav" src="https://user-images.githubusercontent.com/541093/145640512-3d2727c7-c236-452e-88bf-54aa7bb4d1e9.png"> | <img width="482" alt="after-small-post-nav" src="https://user-images.githubusercontent.com/541093/145640505-d3f68723-a2c9-41ed-a1bc-34585dafc4cf.png"> |
| <img width="1386" alt="before-large-post-nav" src="https://user-images.githubusercontent.com/541093/145640509-503b9637-c666-45cb-9a7f-2dda6796ed8e.png"> | <img width="1385" alt="after-large-post-nav" src="https://user-images.githubusercontent.com/541093/145640501-c0545a2b-5a88-448f-a8ec-1cca5040ed2a.png"> |






 