### PR TITLE
Quick temporary fix for See All Releases and See All People

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -21,7 +21,7 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-		<!-- wp:query-pagination-next {"label":"See All Posts"} /-->
+	<a href="./category/uncategorized/" class="wp-block-query-pagination-next">See All Posts</a>
 	<!-- /wp:query-pagination -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -21,7 +21,7 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-	<a href="./category/uncategorized/" class="wp-block-query-pagination-next">See All Posts</a>
+	<a href="./page/2/" class="wp-block-query-pagination-next">See All Posts</a>
 	<!-- /wp:query-pagination -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
@@ -19,7 +19,7 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-		<!-- wp:query-pagination-next {"label":"See All Releases"} /-->
+		<a href="./category/releases/" class="wp-block-query-pagination-next">See All Releases</a>
 	<!-- /wp:query-pagination -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -11,7 +11,7 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination {"layout":"inherit"} -->
-		<!-- wp:query-pagination-next {"label":"See All People"} /-->
+		<a href="./tag/people-of-wordpress/" class="wp-block-query-pagination-next">See All People</a>
 	<!-- /wp:query-pagination -->
 </section>
 <!-- /wp:query -->


### PR DESCRIPTION
I'm not sure how to get the query-pagination-next blocks to work as expected.

This isn't a permanent fix, and doesn't yet cover the All Posts view (where should that live?)
