### PR TITLE
Adding overlay when the local header is open

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -132,6 +132,20 @@
 					svg {
 						transform: rotate(180deg);
 					}
+					
+					&::before {
+						content: "";
+						display: block;
+						position: fixed;
+						top: 0;
+						left: 0;
+						width: 100%;
+						height: 100vh;
+						background-color: rgba(0,0,0,0.5);
+						z-index: -1;
+						animation-duration: 400ms;
+						animation-name: overlay-fade-in;
+					}
 				}
 
 				~ .wp-block-categories {


### PR DESCRIPTION
## Description
Adding overlay when the local header is open
fix part of https://github.com/WordPress/wporg-news-2021/issues/120

## Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/1310626/145863868-09893aa1-442d-44e2-980d-f81dd6fe640a.png)
![image](https://user-images.githubusercontent.com/1310626/145863880-e4d372a7-1b8f-413e-ac67-5eefa75b3553.png)


**After:**
![image](https://user-images.githubusercontent.com/1310626/145863900-530b0046-7690-4937-b97f-06ea17b17e74.png)
![image](https://user-images.githubusercontent.com/1310626/145863939-43ae5973-71a5-4c36-9c1d-16db0dd55a61.png)


## Issue
https://github.com/WordPress/wporg-news-2021/issues/120