### PR TITLE
Use a filter to set posts_per_page for some categories

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
@@ -2,6 +2,7 @@
 <!-- This is a hack to ensure content isn't covered by the fixed header -->
 <!-- wp:template-part {"slug":"header","align":"full","className":"site-header-offset"} /-->
 
+<!-- Note: This query has filters, but they live in `category_posts_per_page()`. That's necessary to avoid a Gutenberg design flaw. -->
 <!-- wp:query {"tagName":"main","className":"site-content-container","query":{"inherit":true},"displayLayout":{"type":"flex","columns":4},"align":"full"} -->
 <main class="wp-block-query site-content-container">
 	<!-- wp:post-template -->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
@@ -2,7 +2,7 @@
 <!-- This is a hack to ensure content isn't covered by the fixed header -->
 <!-- wp:template-part {"slug":"header","align":"full","className":"site-header-offset"} /-->
 
-<!-- wp:query {"tagName":"main","className":"site-content-container","query":{"category":"community","perPage":"20","postType":"post","inherit":false},"displayLayout":{"type":"flex","columns":4},"align":"full"} -->
+<!-- wp:query {"tagName":"main","className":"site-content-container","query":{"inherit":true},"displayLayout":{"type":"flex","columns":4},"align":"full"} -->
 <main class="wp-block-query site-content-container">
 	<!-- wp:post-template -->
 		<!-- wp:template-part {"slug":"content-category-community","tagName":"article","layout":{"inherit":true}} /-->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-month-in-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-month-in-wordpress.html
@@ -2,7 +2,7 @@
 <!-- This is a hack to ensure content isn't covered by the fixed header -->
 <!-- wp:template-part {"slug":"header","align":"full","className":"site-header-offset"} /-->
 
-<!-- wp:query {"tagName":"main","className":"site-content-container","displayLayout":{"type":"flex","columns":4},"query":{"category":"month-in-wordpress","perPage":"10000","inherit":false}} -->
+<!-- wp:query {"tagName":"main","className":"site-content-container","displayLayout":{"type":"flex","columns":4},"query":{"inherit":true}} -->
 <main class="wp-block-query site-content-container">
 	<!-- wp:post-template -->
 		<!-- wp:template-part {"slug":"content-category-month-in-wordpress","tagName":"article","layout":{"inherit":true}} /-->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-month-in-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-month-in-wordpress.html
@@ -2,6 +2,7 @@
 <!-- This is a hack to ensure content isn't covered by the fixed header -->
 <!-- wp:template-part {"slug":"header","align":"full","className":"site-header-offset"} /-->
 
+<!-- Note: This query has filters, but they live in `category_posts_per_page()`. That's necessary to avoid a Gutenberg design flaw. -->
 <!-- wp:query {"tagName":"main","className":"site-content-container","displayLayout":{"type":"flex","columns":4},"query":{"inherit":true}} -->
 <main class="wp-block-query site-content-container">
 	<!-- wp:post-template -->

--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -15,6 +15,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_filter( 'get_the_archive_title_prefix', __NAMESPACE__ . '\modify_archive_title_prefix' );
 add_filter( 'template_include', __NAMESPACE__ . '\override_front_page_template' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\offset_paginated_index_posts' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\category_posts_per_page' );
 add_filter( 'body_class', __NAMESPACE__ . '\clarify_body_classes' );
 add_filter( 'post_class', __NAMESPACE__ . '\specify_post_classes', 10, 3 );
 add_filter( 'theme_file_path', __NAMESPACE__ . '\conditional_template_part', 10, 2 );
@@ -211,6 +212,25 @@ function offset_paginated_index_posts( $query ) {
 	$default_offset      = ( $current_page - 2 ) * $posts_per_page;
 
 	$query->set( 'offset', $default_offset + $posts_on_front_page );
+}
+
+/**
+ * Adjust posts_per_page separately for certain categories.
+ *
+ * We have certain category templates designed for different numbers of posts per page. Unfortunately it's not possible to set this in the block temlates.
+ * (See https://github.com/WordPress/wporg-news-2021/issues/70#issuecomment-996460735)
+ *
+ * @param WP_Query $query
+ */
+function category_posts_per_page( $query ) {
+	if ( $query->is_category() ) {
+		if ( $query->is_category( 'month-in-wordpress' ) ) {
+			$query->set( 'posts_per_page', 600 );
+		}
+		if ( $query->is_category( 'community' ) ) {
+			$query->set( 'posts_per_page', 20 );
+		}
+	}
 }
 
 /**

--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -15,7 +15,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_filter( 'get_the_archive_title_prefix', __NAMESPACE__ . '\modify_archive_title_prefix' );
 add_filter( 'template_include', __NAMESPACE__ . '\override_front_page_template' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\offset_paginated_index_posts' );
-add_action( 'pre_get_posts', __NAMESPACE__ . '\category_posts_per_page' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\override_category_query_args' );
 add_filter( 'body_class', __NAMESPACE__ . '\clarify_body_classes' );
 add_filter( 'post_class', __NAMESPACE__ . '\specify_post_classes', 10, 3 );
 add_filter( 'theme_file_path', __NAMESPACE__ . '\conditional_template_part', 10, 2 );
@@ -215,14 +215,14 @@ function offset_paginated_index_posts( $query ) {
 }
 
 /**
- * Adjust posts_per_page separately for certain categories.
+ * Adjust WP_Query arguments separately for certain categories.
  *
  * We have certain category templates designed for different numbers of posts per page. Unfortunately it's not possible to set this in the block temlates.
  * (See https://github.com/WordPress/wporg-news-2021/issues/70#issuecomment-996460735)
  *
  * @param WP_Query $query
  */
-function category_posts_per_page( $query ) {
+function override_category_query_args( $query ) {
 	if ( $query->is_category() ) {
 		if ( $query->is_category( 'month-in-wordpress' ) ) {
 			$query->set( 'posts_per_page', 600 );


### PR DESCRIPTION
This lets us use `inherit:true` for the `wp:query` blocks in the page templates. Without which we run into problems with pagination etc.

See #70 for discussion.