### PR TITLE
Design Fixes: Left-align footer navigation menus

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/footer-archive/_footer-archive.scss
@@ -40,6 +40,11 @@
 			}
 		}
 	}
+
+	// Left-align footer navigation menus
+	.wp-block-group.global-footer .wp-block-navigation__container {
+		align-items: self-start;
+	}
 }
 
 // Alternate dark version.


### PR DESCRIPTION
This PR left-aligns the footer navigation menus. 

Note: This fix overrides a style from an mu-plugin which can be found here: 
`/wporg-news-2021/source/wp-content/mu-plugins/wporg-mu-plugins/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss`

Since that plugin isn’t part of this project, this override is necessary to correct the alignment. 

Before: 
![image](https://user-images.githubusercontent.com/709581/148787319-e77a3c5d-f247-48d4-a565-5d9e87b8d3f6.png)

After: 
![image](https://user-images.githubusercontent.com/709581/148787404-c50fce67-44f4-4cbc-9e8a-1153a4d129f8.png)

Fixes: #153