### PR TITLE
Move pagination from template-part to the main templates

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/query-navigation.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/query-navigation.html
@@ -1,7 +1,0 @@
-<!-- wp:query-pagination -->
-<div class="wp-block-query-pagination">
-	<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
-	<!-- wp:query-pagination-numbers /-->
-	<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-</div>
-<!-- /wp:query-pagination -->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
@@ -9,7 +9,15 @@
 		<!-- wp:template-part {"slug":"content-category-community","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->
 
-	<!-- wp:template-part {"slug":"query-navigation","className":"query-navigation-container","layout":{"inherit":true}} /-->
+	<!-- wp:query-pagination -->
+	<div class="wp-block-query-pagination">
+		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
+	</div>
+	<!-- /wp:query-pagination -->
+
+
 </main>
 <!-- /wp:query -->
 

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-events.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-events.html
@@ -8,7 +8,14 @@
 		<!-- wp:template-part {"slug":"content-category-events","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->
 
-	<!-- wp:template-part {"slug":"query-navigation","className":"query-navigation-container","layout":{"inherit":true}} /-->
+	<!-- wp:query-pagination -->
+	<div class="wp-block-query-pagination">
+		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
+	</div>
+	<!-- /wp:query-pagination -->
+
 </main>
 <!-- /wp:query -->
 

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-releases.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-releases.html
@@ -8,7 +8,13 @@
 		<!-- wp:template-part {"slug":"content-category-releases","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->
 
-	<!-- wp:template-part {"slug":"query-navigation","className":"query-navigation-container","layout":{"inherit":true}} /-->
+	<!-- wp:query-pagination -->
+	<div class="wp-block-query-pagination">
+		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
+	</div>
+	<!-- /wp:query-pagination -->
 </main>
 <!-- /wp:query -->
 

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category.html
@@ -8,7 +8,14 @@
 		<!-- wp:template-part {"slug":"content-posts-index","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->
 
-	<!-- wp:template-part {"slug":"query-navigation","className":"query-navigation-container","layout":{"inherit":true}} /-->
+	<!-- wp:query-pagination -->
+	<div class="wp-block-query-pagination">
+		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
+	</div>
+	<!-- /wp:query-pagination -->
+
 </main>
 <!-- /wp:query -->
 

--- a/source/wp-content/themes/wporg-news-2021/block-templates/index.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/index.html
@@ -15,7 +15,14 @@
 		<!-- wp:template-part {"slug":"content-posts-index","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->
 
-	<!-- wp:template-part {"slug":"query-navigation","className":"query-navigation-container","layout":{"inherit":true}} /-->
+	<!-- wp:query-pagination -->
+	<div class="wp-block-query-pagination">
+		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
+	</div>
+	<!-- /wp:query-pagination -->
+
 </main>
 <!-- /wp:query -->
 


### PR DESCRIPTION
It seems that query context isn't passed into template parts(!). This means that query-pagination blocks must be in the same template file as the query block or they won't work.

Related: https://github.com/WordPress/gutenberg/issues/28011

Fixes (most of) #70.