### PR TITLE
Fix pagination width/alignment

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
@@ -1,4 +1,5 @@
 .post-navigation {
+	--wp--custom--layout--content-size: 100%;
 	padding-bottom: var(--wp--style--block-gap);
 	display: flex;
 	justify-content: space-between;


### PR DESCRIPTION
This PR reset core `layout--content-size` variable to 100% with in the `.post-navigation` context. 

Before (local): 
![image](https://user-images.githubusercontent.com/709581/149027322-56ce0efb-67ca-4536-9239-ae581671e8e8.png)

After: 
![image](https://user-images.githubusercontent.com/709581/149027000-69f000f4-391c-4f05-bae5-46bf2b2cace4.png)

Original Figma Design: 
![image](https://user-images.githubusercontent.com/709581/149027119-712ae1ff-0cb4-40df-8db3-ff91421f6f65.png)

Fixes: #152 