### PR TITLE
Fix z-index of see all people link

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -11,7 +11,7 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination {"layout":"inherit"} -->
-		<!-- wp:query-pagination-next {"label":"See All People"} /-->
+		<!-- wp:query-pagination-next {"label":"See all people"} /-->
 	<!-- /wp:query-pagination -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_people-of-wordpress.scss
@@ -78,6 +78,10 @@ body.news-front-page .front__people-of-wordpress {
 	.wp-block-query-pagination {
 		margin-top: 0;
 
+		a {
+			position: relative;
+		}
+
 		&::after {
 			background-color: var(--wp--preset--color--white);
 		}


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-news-2021/issues/168

Make sure the "See all people" link matches the mockups, and it shows above the background graphic.

**Before:**
<img width="406" alt="Screen Shot 2022-01-11 at 3 37 09 PM" src="https://user-images.githubusercontent.com/1464705/149038149-da296a1c-4b94-466f-9b90-f525eb4eafa8.png">


**After**

<img width="482" alt="Screen Shot 2022-01-11 at 3 36 53 PM" src="https://user-images.githubusercontent.com/1464705/149038159-35136677-630a-4008-87ae-74fceacef446.png">


