### PR TITLE
Fix stroke on category pages paginations

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
@@ -8,11 +8,9 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination">
 		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
 		<!-- wp:query-pagination-numbers /-->
 		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-	</div>
 	<!-- /wp:query-pagination -->
 
 

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-events.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-events.html
@@ -7,11 +7,9 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination">
 		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
 		<!-- wp:query-pagination-numbers /-->
 		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-	</div>
 	<!-- /wp:query-pagination -->
 
 </main>

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-releases.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-releases.html
@@ -7,11 +7,9 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination">
 		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
 		<!-- wp:query-pagination-numbers /-->
 		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-	</div>
 	<!-- /wp:query-pagination -->
 </main>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category.html
@@ -7,11 +7,9 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination">
 		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
 		<!-- wp:query-pagination-numbers /-->
 		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-	</div>
 	<!-- /wp:query-pagination -->
 
 </main>

--- a/source/wp-content/themes/wporg-news-2021/block-templates/index.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/index.html
@@ -14,11 +14,9 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination">
 		<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
 		<!-- wp:query-pagination-numbers /-->
 		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-	</div>
 	<!-- /wp:query-pagination -->
 
 </main>

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
@@ -8,7 +8,7 @@
 	color: var(--wp--preset--color--blue-1);
 	position: relative;
 
-	body.archive & {
+	body:where(.archive, .blog.paged) & {
 		padding: 40px 0;
 
 		@include break-small-only() {

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
@@ -14,6 +14,7 @@
 		@include break-small-only() {
 			display: flex;
 			justify-content: center;
+
 			&::after {
 				mask-position: center;
 			}
@@ -29,14 +30,13 @@
 	}
 
 	&::after {
-		--stroke-color: var(--wp--preset--color--off-white-2); 
 		content: "";
 		position: absolute;
 		top: 0;
 		bottom: 0;
 		right: 0;
 		left: 0;
-		background-color: var(--stroke-color);
+		background-color: var(--wp--preset--color--off-white-2);
 		mask-image: url(images/brush-stroke-short-blue-4.svg);
 		mask-position: bottom left;
 		mask-repeat: no-repeat;

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
@@ -8,18 +8,26 @@
 	color: var(--wp--preset--color--blue-1);
 	position: relative;
 
+	body.archive & {
+		@include break-small-only() {
+			display: flex;
+			justify-content: center;
+		}
+	}
+
 	.wp-block-query-pagination-next {
 		z-index: 2;
 	}
 
 	&::after {
+		--stroke-color: var(--wp--preset--color--off-white-2); 
 		content: "";
 		position: absolute;
 		top: 0;
 		bottom: 0;
 		right: 0;
 		left: 0;
-		background-color: var(--wp--preset--color--off-white-2);
+		background-color: var(--stroke-color);
 		mask-image: url(images/brush-stroke-short-blue-4.svg);
 		mask-position: bottom left;
 		mask-repeat: no-repeat;

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
@@ -9,9 +9,18 @@
 	position: relative;
 
 	body.archive & {
+		padding: 40px 0;
+
 		@include break-small-only() {
 			display: flex;
 			justify-content: center;
+			&::after {
+				mask-position: center;
+			}
+		}
+
+		&::after {
+			z-index: -1;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -37,7 +37,7 @@ body.category-releases {
 	}
 
 	.wp-block-query-pagination::after {
-		--stroke-color: var(--contrast-color);
+		background-color: var(--contrast-color);
 	}
 
 	@extend %footer-archive-dark;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -13,6 +13,8 @@ body.category-events {
 }
 
 body.category-releases {
+	--contrast-color: var(--wp--preset--color--blue-5);
+
 	.wp-site-blocks {
 		background-color: var(--wp--preset--color--blue-1);
 	}
@@ -31,11 +33,11 @@ body.category-releases {
 	}
 
 	.local-header {
-		--bar-background-color: var(--wp--preset--color--blue-5);
+		--bar-background-color: var(--contrast-color);
 	}
 
 	.wp-block-query-pagination::after {
-		background-color: var(--wp--preset--color--blue-5);
+		--stroke-color: var(--contrast-color);
 	}
 
 	@extend %footer-archive-dark;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -34,6 +34,10 @@ body.category-releases {
 		--bar-background-color: var(--wp--preset--color--blue-5);
 	}
 
+	.wp-block-query-pagination::after {
+		background-color: var(--wp--preset--color--blue-5);
+	}
+
 	@extend %footer-archive-dark;
 }
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -256,8 +256,9 @@
 			--bar-link-hover-color: var(--wp--preset--color--blue-1);
 		}
 	}
+
 	.wp-block-query-pagination::after {
-		--stroke-color: var(--contrast-color);
+		background-color: var(--contrast-color);
 	}
 }
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -244,18 +244,20 @@
 
 // Alternate off-white version.
 %local-header-off-white {
+	--contrast-color: var(--wp--preset--color--white);
+
 	.wp-site-blocks {
 		background-color: var(--wp--preset--color--off-white);
 
 		.local-header {
-			--bar-background-color: var(--wp--preset--color--white);
+			--bar-background-color: var(--contrast-color);
 			--bar-text-color: var(--wp--preset--color--black);
 			--bar-link-color: var(--wp--preset--color--blue-1);
 			--bar-link-hover-color: var(--wp--preset--color--blue-1);
 		}
 	}
 	.wp-block-query-pagination::after {
-		background-color: var(--wp--preset--color--white);
+		--stroke-color: var(--contrast-color);
 	}
 }
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -254,6 +254,9 @@
 			--bar-link-hover-color: var(--wp--preset--color--blue-1);
 		}
 	}
+	.wp-block-query-pagination::after {
+		background-color: var(--wp--preset--color--white);
+	}
 }
 
 // Alternate version with a color light enough to need dark text. e.g., Security category.


### PR DESCRIPTION
This PR fixes the positioning and color of the stroke on the category pages with pagination.

![Screen Capture on 2022-01-12 at 12-54-38](https://user-images.githubusercontent.com/3593343/149135955-517d2363-14f8-40bf-8e80-74392ceeb88d.gif)


Closes https://github.com/WordPress/wporg-news-2021/issues/185
Closes https://github.com/WordPress/wporg-news-2021/issues/186