### PR TITLE
Post Navigation: Update "dot" separator and improve responsive styles

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
@@ -9,20 +9,37 @@
 			display: flex;
 			flex-direction: column;
 
-			@include break-medium() {
-				gap: 1ch;
+			@include break-large() {
+				gap: 3ch;
 				flex-direction: row;
+			}
+
+			.post-navigation-link__label {
+				position: relative;
+
+				@include break-large() {
+					&::after {
+						display: block;
+						content: "";
+						height: 2px;
+						width: 2px;
+						background: var(--wp--preset--color--blue-1);
+						position: absolute;
+						top: calc(50% - 1px);
+					}
+				}
+			}
+
+			.post-navigation-link__title {
+				white-space: nowrap;
 			}
 		}
 
 		&.post-navigation-link-previous {
-			span {
-				white-space: nowrap;
-			}
 
-			@include break-medium() {
+			@include break-large() {
 				.post-navigation-link__label::after {
-					content: " \00B7\0020";
+					right: calc(-1.5ch - 1px);
 				}
 			}
 		}
@@ -30,14 +47,13 @@
 		&.post-navigation-link-next {
 			text-align: end;
 
-			@include break-medium() {
+			@include break-large() {
 				a {
 					flex-direction: row-reverse;
 				}
 
-				.post-navigation-link__label::before {
-					content: " \0020\00B7";
-					padding-right: 0.3em;
+				.post-navigation-link__label::after {
+					left: calc(-1.5ch - 2px);
 				}
 			}
 		}


### PR DESCRIPTION
At the bottom of each blog post there are Next and Previous links, which also include the title of those next/previous posts. This information is separated by a dot, which is currently just a normal character. The problem is this character gets underlined when hovered:

<img width="288" alt="image" src="https://user-images.githubusercontent.com/191598/149208173-d319f342-45f6-4f05-b0ce-cfcadf822ca8.png">

<img width="310" alt="image" src="https://user-images.githubusercontent.com/191598/149208192-8f99bbfd-ffda-472d-92fc-428df8ec0f41.png">

This PR replaces this character (which was added using `content`) with a rendered dot. This fixes the unintended underlines:

<img width="475" alt="image" src="https://user-images.githubusercontent.com/191598/149208286-5ebe0d37-1a65-41b7-b11b-990ff8a11938.png">

--

In addition, this PR also adds some updates to the way long lines break at some viewport widths. Currently the post titles might wrap to multiple lines if there's not enough room to have everything on a single line:

<img width="826" alt="image" src="https://user-images.githubusercontent.com/191598/149208553-f205d04f-b192-4fe4-9abc-47db3ef837d1.png">

This PR adjusts the layout to use two-lines at these awkward breakpoints:

<img width="828" alt="image" src="https://user-images.githubusercontent.com/191598/149208625-28a5d7aa-8cee-4c0e-b96e-b641d381146e.png">


