### PR TITLE
Make the Get WordPress button wider

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_navigation.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_navigation.scss
@@ -1,0 +1,7 @@
+.wp-block-group.global-header .global-header__navigation .wp-block-navigation__responsive-container.is-menu-open {
+	padding: 2rem 0;
+
+	.wp-block-navigation__container {
+		width: 100%;
+	}
+}

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_navigation.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_navigation.scss
@@ -1,4 +1,4 @@
-.wp-block-group.global-header .global-header__navigation .wp-block-navigation__responsive-container.is-menu-open {
+.wp-block-navigation__responsive-container.is-menu-open {
 	padding: 2rem 0;
 
 	.wp-block-navigation__container {

--- a/source/wp-content/themes/wporg-news-2021/sass/style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/style.scss
@@ -66,6 +66,7 @@ GNU General Public License for more details.
 @import "blocks/table";
 @import "blocks/video";
 @import "blocks/columns";
+@import "blocks/navigation";
 
 
 // Components


### PR DESCRIPTION
Closes #180 

<img width="610" alt="News_Theme_2021_Test_–_Testing_github_com_WordPress_wporg-news-2021" src="https://user-images.githubusercontent.com/905781/149251838-c479ce4d-ce9d-4de4-9e5d-415f62756b24.png">

