### PR TITLE
Footer text and links font size should match the header 13px

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_navigation.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_navigation.scss
@@ -1,0 +1,6 @@
+.global-footer .wp-block-navigation {
+
+	@include break-medium {
+		font-size: 13px;
+	}
+}

--- a/source/wp-content/themes/wporg-news-2021/sass/style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/style.scss
@@ -51,6 +51,7 @@ GNU General Public License for more details.
 @import "blocks/image";
 @import "blocks/latest-posts";
 @import "blocks/list";
+@import "blocks/navigation";
 @import "blocks/paragraph";
 @import "blocks/post-author";
 @import "blocks/post-comments";


### PR DESCRIPTION
Resolves: https://github.com/WordPress/wporg-news-2021/issues/170

Let's add a navigation style override so we can define the footer nav font size match the default header font size!

| Before  | After |
| ------------- | ------------- |
| <img width="300" alt="Screen Shot 2022-01-13 at 3 52 29 pm" src="https://user-images.githubusercontent.com/6458278/149267980-80f10ab9-0abe-471f-8329-3b112f92f77d.png">  | <img width="300" alt="Screen Shot 2022-01-13 at 3 52 14 pm" src="https://user-images.githubusercontent.com/6458278/149267984-7ea8ef22-0990-4537-8d46-8daeefcb89a0.png">  |




I'm not familiar with the file system preferences, so I wasn't sure whether to add this style to [sass/components/_site-header.scss](https://github.com/ramonjd/wporg-news-2021/blob/a8e68a045ce487cca7f62956b6d34d8231fcc2c8/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss).

Creating a new _navigation.scss file seemed right since we're dealing with a nav block.

The default font-size (`13px`) for the header comes from the header.pcss file generated in `wporg-mu-plugins`. 


