### PR TITLE
Fix local nav bar visual elements

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -55,9 +55,9 @@
 
 			&::before {
 				content: "\2022";
-				font-size: 0.75rem;
+				font-size: 0.5rem;
 				display: inline-block;
-				margin: 0 12px;
+				margin: 0 0.5rem;
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -54,10 +54,13 @@
 			}
 
 			&::before {
-				content: "\2022";
-				font-size: 0.5rem;
+				content: "";
+				height: 2px;
+				width: 2px;
+				background: var(--bar-text-color);
 				display: inline-block;
 				margin: 0 0.5rem;
+				border-radius: 2px;
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -49,8 +49,8 @@
 			}
 
 			&::before {
-				height: 2px;
-				width: 2px;
+				height: 3px;
+				width: 3px;
 				border-radius: 100%;
 				content: "";
 				background: var(--bar-text-color);

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -51,6 +51,7 @@
 			&::before {
 				height: 4px;
 				width: 4px;
+				border-radius: 100%;
 				content: "";
 				background: var(--bar-text-color);
 				display: inline-block;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -49,8 +49,8 @@
 			}
 
 			&::before {
-				height: 4px;
-				width: 4px;
+				height: 2px;
+				width: 2px;
 				border-radius: 100%;
 				content: "";
 				background: var(--bar-text-color);

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -23,6 +23,11 @@
 		@include break-small {
 			padding: 0 var(--wp--custom--alignment--edge-spacing);
 		}
+
+		// Override core navigation block link color
+		.wp-block-navigation .wp-block-navigation-item__content {
+			color: var(--bar-link-color);
+		}
 	}
 
 	// Breadcrumbs show the lineage of pages based on the current
@@ -49,11 +54,8 @@
 			}
 
 			&::before {
-				height: 3px;
-				width: 3px;
-				border-radius: 100%;
-				content: "";
-				background: var(--bar-text-color);
+				content: "\2022";
+				font-size: 0.75rem;
 				display: inline-block;
 				margin: 0 12px;
 			}


### PR DESCRIPTION
This PR changes the square separator to a circular shape and adjusts the default color state for the News link. 

Before: 
![image](https://user-images.githubusercontent.com/709581/149371836-9d53f753-3920-4820-9b8d-c89810a0548d.png)

After: 
![image](https://user-images.githubusercontent.com/709581/149371899-28eafa77-d183-49b7-8a3f-378341013c6f.png)

Figma reference: 
![image](https://user-images.githubusercontent.com/709581/149371960-e44daf0e-48f3-4fa6-94e5-396caf945310.png)

Note: I replaced the pseudo element square shape with a unicode "bullet" method which requires a few less lines of code. I tried to simply add a border radius, but once that shape got below 3px, the border-radius had no effect. 

Fixes: #194 