### PR TITLE
Add line height value to latest release title

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_latest-release.scss
@@ -30,6 +30,7 @@ body.news-front-page .front__latest-release {
 			font-size: var(--header-size);
 			font-family: var(--wp--preset--font-family--inter);
 			font-weight: 200;
+			line-height: 1.1;
 		}
 	}
 


### PR DESCRIPTION
This PR adds a line-height value to the latest release title. 

<img width="1538" alt="Screenshot 2022-01-14 at 10 35 05" src="https://user-images.githubusercontent.com/3593343/149493245-3ff3c775-5c24-4b6f-b1cc-c0a9760ec038.png">

I did not see any grid-related issues coming from this change @apeatling, can you tell me what you saw when you tried this? 

@tellyworth the Latest Release text to the left looks too small compared to the figma files, should we fix this too?

Closes https://github.com/WordPress/wporg-news-2021/issues/165
