### PR TITLE
Starting styles for month in WP category

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-month-in-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-month-in-wordpress.html
@@ -1,9 +1,9 @@
 <!-- wp:template-part {"slug":"header","align":"full","className":"site-header-container"} /-->
 
 <!-- Note: This query has filters, but they live in `category_posts_per_page()`. That's necessary to avoid a Gutenberg design flaw. -->
-<!-- wp:query {"tagName":"main","className":"site-content-container","displayLayout":{"type":"flex","columns":4},"query":{"inherit":true}} -->
+<!-- wp:query {"tagName":"main","className":"site-content-container","displayLayout":{"type":"flex","columns":3},"query":{"inherit":true}} -->
 <main class="wp-block-query site-content-container">
-	<!-- wp:post-template -->
+	<!-- wp:post-template {"align":"wide"} -->
 		<!-- wp:template-part {"slug":"content-category-month-in-wordpress","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -53,6 +53,9 @@ body.category-month-in-wordpress {
 	.wp-block-post {
 		text-align: center;
 		margin-bottom: 40px;
+		@include break-small-only() {
+			width: 50%;
+		}
 	}
 
 	.wp-block-post-date {
@@ -76,7 +79,7 @@ body.category-month-in-wordpress {
 	}
 
 	h2 time {
-		font-size: 120px;
+		font-size: min(max(50px, 5vw), 120px);
 		line-height: 1;
 		a:hover,
 		a:focus {

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -109,7 +109,8 @@ body.category-month-in-wordpress {
 
 		a:hover,
 		a:focus {
-			text-decoration: none;
+			color: #7b90ff;
+			text-decoration-thickness: 1px;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -109,7 +109,7 @@ body.category-month-in-wordpress {
 
 		a:hover,
 		a:focus {
-			color: #7b90ff;
+			color: var(--wp--preset--color--blue-3);
 			text-decoration-thickness: 1px;
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -66,16 +66,21 @@ body.category-month-in-wordpress {
 		}
 	}
 
-	.last-in-year::after {
-		content: none;//"-";Removing temporarily
-		display: inline-block;
-		line-height: calc(var(--wp--custom--margin--vertical) * 6);
-		width: 100%;
-		background-image: url(images/brush-stroke-short-blue-4.svg);
-		background-position: center;
-		background-repeat: no-repeat;
-		//background-size: fill;
-		color: var(--wp--preset--color--blue-1);
+	.last-in-year {
+		break-after: always;
+		&::after {
+			content: none;//"-";Removing temporarily
+			//display: inline-block;
+			line-height: calc(var(--wp--custom--margin--vertical) * 6);
+			width: 100%;
+			flex-grow: 1;
+			flex-basis: 100%;
+			background-image: url(images/brush-stroke-short-blue-4.svg);
+			background-position: center;
+			background-repeat: no-repeat;
+			//background-size: fill;
+			color: var(--wp--preset--color--blue-1);
+		}
 	}
 
 	h2 time {

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -46,13 +46,13 @@ body.category-month-in-wordpress {
 	}
 
 	.wp-block-post-template {
-		margin-top: 60px;
-		margin-bottom: 60px;
+		margin-top: calc(var(--wp--custom--margin--vertical) * 2);
+		margin-bottom: calc(var(--wp--custom--margin--vertical) * 2);
 	}
 
 	.wp-block-post {
 		text-align: center;
-		margin-bottom: 40px;
+		margin-bottom: calc(var(--wp--custom--margin--vertical) * 1.333);
 		@include break-small-only() {
 			width: 50%;
 		}
@@ -67,19 +67,31 @@ body.category-month-in-wordpress {
 	}
 
 	.last-in-year {
+		/* We are removing this item from the grid so we can make the ::after element work as a child of the grid*/
+		display: contents;
+		position: relative;
 		break-after: always;
 		&::after {
-			content: none;//"-";Removing temporarily
-			//display: inline-block;
+			content: "-";
 			line-height: calc(var(--wp--custom--margin--vertical) * 6);
 			width: 100%;
-			flex-grow: 1;
-			flex-basis: 100%;
-			background-image: url(images/brush-stroke-short-blue-4.svg);
-			background-position: center;
-			background-repeat: no-repeat;
-			//background-size: fill;
-			color: var(--wp--preset--color--blue-1);
+			mask-image: url(images/brush-stroke-big.svg);
+			mask-position: center;
+			mask-repeat: no-repeat;
+			mask-size: 100% auto;
+			background-color: var(--wp--preset--color--blue-1);
+			transform: translateY(-25%);
+			@include break-small() {
+				mask-size: 280px auto;
+			}
+		}
+		article {
+			/* We are making the article look like it's a child of the grid container */
+			width: calc(33.33333% - .83333em);
+			margin-bottom: calc(var(--wp--custom--margin--vertical) * 2.5);
+			@include break-small-only() {
+				width: 50%;
+			}
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -45,13 +45,26 @@ body.category-month-in-wordpress {
 		color: var(--wp--preset--color--off-white-2);
 	}
 
-	.wp-block-post-date a {
-		color: var(--wp--preset--color--off-white-2);
-		text-transform: uppercase;
+	.wp-block-post-template {
+		margin-top: 60px;
+		margin-bottom: 60px;
+	}
+
+	.wp-block-post {
+		text-align: center;
+		margin-bottom: 40px;
+	}
+
+	.wp-block-post-date {
+		font-size: var(--wp--preset--font-size--normal);
+		a {
+			color: var(--wp--preset--color--off-white-2);
+			text-transform: uppercase;
+		}
 	}
 
 	.last-in-year::after {
-		content: "-";
+		content: none;//"-";Removing temporarily
 		display: inline-block;
 		line-height: calc(var(--wp--custom--margin--vertical) * 6);
 		width: 100%;
@@ -60,6 +73,15 @@ body.category-month-in-wordpress {
 		background-repeat: no-repeat;
 		//background-size: fill;
 		color: var(--wp--preset--color--blue-1);
+	}
+
+	h2 time {
+		font-size: 120px;
+		line-height: 1;
+		a:hover,
+		a:focus {
+			text-decoration: none;
+		}
 	}
 
 	@extend %footer-archive-dark;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -53,6 +53,7 @@ body.category-month-in-wordpress {
 	.wp-block-post {
 		text-align: center;
 		margin-bottom: calc(var(--wp--custom--margin--vertical) * 1.333);
+
 		@include break-small-only() {
 			width: 50%;
 		}
@@ -60,6 +61,7 @@ body.category-month-in-wordpress {
 
 	.wp-block-post-date {
 		font-size: var(--wp--preset--font-size--normal);
+
 		a {
 			color: var(--wp--preset--color--off-white-2);
 			text-transform: uppercase;
@@ -67,10 +69,12 @@ body.category-month-in-wordpress {
 	}
 
 	.last-in-year {
+
 		/* We are removing this item from the grid so we can make the ::after element work as a child of the grid*/
 		display: contents;
 		position: relative;
 		break-after: always;
+
 		&::after {
 			content: "-";
 			line-height: calc(var(--wp--custom--margin--vertical) * 6);
@@ -81,14 +85,18 @@ body.category-month-in-wordpress {
 			mask-size: 100% auto;
 			background-color: var(--wp--preset--color--blue-1);
 			transform: translateY(-25%);
+
 			@include break-small() {
 				mask-size: 280px auto;
 			}
 		}
+
 		article {
+
 			/* We are making the article look like it's a child of the grid container */
-			width: calc(33.33333% - .83333em);
+			width: calc(33.33333% - 0.83333em);
 			margin-bottom: calc(var(--wp--custom--margin--vertical) * 2.5);
+
 			@include break-small-only() {
 				width: 50%;
 			}
@@ -98,6 +106,7 @@ body.category-month-in-wordpress {
 	h2 time {
 		font-size: min(max(50px, 5vw), 120px);
 		line-height: 1;
+
 		a:hover,
 		a:focus {
 			text-decoration: none;


### PR DESCRIPTION
Partially addresses https://github.com/WordPress/wporg-news-2021/issues/148

I went ahead and added a few starting styles to the month in WP category page. I hope it's ok to do this at this stage.

I removed the stroke, I don't think the `last-in-year` class is enough to achieve the design. I'm happy to keep working on that but I wanted to get something that didn't look super broken as a start.

Desktop:

![Screenshot 2022-01-14 at 12-01-19 Month in WordPress – wporg-news-2021](https://user-images.githubusercontent.com/3593343/149505465-acaba108-6cac-4899-a643-a8311b567b40.png)

Mobile:

![Screenshot 2022-01-14 at 12-50-39 Month in WordPress – wporg-news-2021](https://user-images.githubusercontent.com/3593343/149511182-c8914442-1505-4417-9214-38d791c276ee.png)

