### PR TITLE
Start community category styles

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category-community.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category-community.html
@@ -1,10 +1,10 @@
 <!-- wp:group {"tagName":"header","className":"entry-header",style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}}} -->
 <header class="wp-block-group entry-header">
-	<!-- wp:post-title {"level":3,"isLink":true} /-->
 	<!-- wp:post-featured-image {"isLink":true,"width":"200","height":"200"} /-->
 
 	<!-- wp:group {"className":"entry-meta"} -->
 	<div class="wp-block-group entry-meta">
+		<!-- wp:post-title {"level":3,"isLink":true} /-->
 		<!-- wp:post-date /-->
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category-community.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category-community.html
@@ -4,7 +4,7 @@
 
 	<!-- wp:group {"className":"entry-meta"} -->
 	<div class="wp-block-group entry-meta">
-		<!-- wp:post-title {"level":3,"isLink":true} /-->
+		<!-- wp:post-title {"level":2,"isLink":true} /-->
 		<!-- wp:post-date /-->
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-community.html
@@ -1,9 +1,9 @@
 <!-- wp:template-part {"slug":"header","align":"full","className":"site-header-container"} /-->
 
 <!-- Note: This query has filters, but they live in `category_posts_per_page()`. That's necessary to avoid a Gutenberg design flaw. -->
-<!-- wp:query {"tagName":"main","className":"site-content-container","query":{"inherit":true},"displayLayout":{"type":"flex","columns":4},"align":"full"} -->
+<!-- wp:query {"tagName":"main","className":"site-content-container","query":{"inherit":true},"displayLayout":{"type":"flex","columns":4}} -->
 <main class="wp-block-query site-content-container">
-	<!-- wp:post-template -->
+	<!-- wp:post-template {"align":"wide"} -->
 		<!-- wp:template-part {"slug":"content-category-community","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -171,14 +171,10 @@ body.category-community {
 					opacity: 0;
 					color: var(--wp--preset--color--white);
 					position: absolute;
-					top: 0;
 					left: 0;
 					right: 0;
 					bottom: 0;
 					z-index: 1;
-					display: flex;
-					flex-direction: column;
-					justify-content: flex-end;
 				}
 			}
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -109,7 +109,6 @@ body.category-community {
 		a:hover,
 		a:focus {
 			color: inherit;
-			text-decoration: none;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -92,7 +92,12 @@ body.category-community {
 		padding: 0;
 		margin-top: 0;
 
-		@include break-small() {
+		@include break-medium() {
+			padding-left: 0;
+			padding-right: 0;
+		}
+
+		@include break-large() {
 			padding-left: var(--wp--custom--alignment--edge-spacing);
 			padding-right: var(--wp--custom--alignment--edge-spacing);
 		}
@@ -100,6 +105,18 @@ body.category-community {
 
 	.wp-block-post-template {
 		gap: 2px;
+
+		&.is-flex-container.columns-4 > li{
+			@include break-small() {
+				width: calc(50% - 2px);
+			}
+			@include break-medium() {
+				width: calc(33.333% - 2px);
+			}
+			@include break-large() {
+				width: calc(25% - 2px);
+			}
+		}
 	}
 
 	.wp-block-post-title {

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -88,33 +88,68 @@ body.category-community {
 
 	@extend %local-header-lightish;
 
-	.wp-block-post-title,
+	.wp-block-post-template {
+		gap: 2px;
+	}
+
+	.wp-block-post-title{
+		font-size: var(--wp--preset--font-size--huge);
+		line-height: 1.3;
+
+		a:hover,
+		a:focus {
+			color: inherit;
+			text-decoration: none;
+		}
+	}
+
 	.wp-block-post-date {
-		font-size: var(--wp--preset--font--size--tiny);
+		font-size: var(--wp--preset--font-size--small);
 	}
 
-	// Alternating blue-1 and blue-2 for non-thumbnail posts
-	li.post:not(.has-post-thumbnail):nth-of-type(even) {
-		background-color: var(--wp--preset--color--blue-1);
-		color: var(--wp--preset--color--white);
-		vertical-align: bottom;
+	li.post {
+		aspect-ratio: 1 / 1;
+		margin: 0;
+
+		&.has-post-thumbnail {
+			.wp-block-template-part,
+			header,
+			figure,
+			figure a,
+			img {
+				height: 100%;
+			}
+			// B&W featured image
+			.wp-block-post-featured-image {
+				filter: grayscale(100%);
+				object-fit: cover;
+			}
+		}
+
+		
+		&:not(.has-post-thumbnail) {
+			padding: 24px;
+			display: flex;
+			align-items: flex-end;
+			
+			// Alternating blue-1 and blue-2 for non-thumbnail posts
+			&:nth-of-type(even) {
+				background-color: var(--wp--preset--color--blue-1);
+				color: var(--wp--preset--color--white);
+				vertical-align: bottom;
+			}
+
+			&:nth-of-type(odd) {
+				background-color: var(--wp--preset--color--blue-2);
+				color: var(--wp--preset--color--white);
+				vertical-align: bottom;
+			}
+		}
+		// Featured image only for posts that have one
+		&.has-post-thumbnail .wp-block-post-title,
+		&.has-post-thumbnail .entry-meta {
+			display: none;
+		}
 	}
 
-	li.post:not(.has-post-thumbnail):nth-of-type(odd) {
-		background-color: var(--wp--preset--color--blue-2);
-		color: var(--wp--preset--color--white);
-		vertical-align: bottom;
-	}
-
-	// Featured image only for posts that have one
-	li.post.has-post-thumbnail .wp-block-post-title,
-	li.post.has-post-thumbnail .entry-meta {
-		display: none;
-	}
-
-	// B&W featured image
-	li.post.has-post-thumbnail .wp-block-post-featured-image {
-		filter: grayscale(100%);
-		object-fit: cover;
-	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -87,11 +87,11 @@ body.category-security {
 body.category-community {
 
 	@extend %local-header-lightish;
-	//.wp-site-blocks > :not(.site-header-container):not(.local-header):not(.global-footer):not(.footer-archive)
 
-	.wp-site-blocks  > .site-content-container:not(.site-header-container):not(.local-header):not(.global-footer):not(.footer-archive) {
+	.wp-site-blocks > .site-content-container:not(.site-header-container):not(.local-header):not(.global-footer):not(.footer-archive) {
 		padding: 0;
 		margin-top: 0;
+
 		@include break-small() {
 			padding-left: var(--wp--custom--alignment--edge-spacing);
 			padding-right: var(--wp--custom--alignment--edge-spacing);
@@ -102,7 +102,7 @@ body.category-community {
 		gap: 2px;
 	}
 
-	.wp-block-post-title{
+	.wp-block-post-title {
 		font-size: var(--wp--preset--font-size--huge);
 		line-height: 1.3;
 
@@ -134,6 +134,7 @@ body.category-community {
 			figure,
 			figure a,
 			img {
+
 				@include break-small() {
 					height: 100%;
 				}
@@ -145,7 +146,7 @@ body.category-community {
 			}
 		}
 
-		
+
 		&:not(.has-post-thumbnail) {
 			min-height: 80vh;
 			display: flex;
@@ -154,7 +155,7 @@ body.category-community {
 			@include break-small() {
 				min-height: 0;
 			}
-			
+
 			// Alternating blue-1 and blue-2 for non-thumbnail posts
 			&:nth-of-type(even) {
 				background-color: var(--wp--preset--color--blue-1);
@@ -170,6 +171,7 @@ body.category-community {
 		}
 		// Featured image only for posts that have one
 		&.has-post-thumbnail .entry-meta {
+
 			@include break-small() {
 				display: none;
 			}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -106,13 +106,16 @@ body.category-community {
 	.wp-block-post-template {
 		gap: 2px;
 
-		&.is-flex-container.columns-4 > li{
+		&.is-flex-container.columns-4 > li {
+
 			@include break-small() {
 				width: calc(50% - 2px);
 			}
+
 			@include break-medium() {
 				width: calc(33.333% - 2px);
 			}
+
 			@include break-large() {
 				width: calc(25% - 2px);
 			}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -128,6 +128,8 @@ body.category-community {
 		}
 
 		&.has-post-thumbnail {
+			position: relative;
+
 			.wp-block-template-part,
 			header,
 			figure,
@@ -146,6 +148,39 @@ body.category-community {
 					filter: grayscale(100%);
 				}
 			}
+
+			@include break-small() {
+				&:hover,
+				&:focus-within {
+					figure {
+						transition: all 0.3s ease-in-out;
+						background-color: var(--wp--preset--color--blue-1);
+					}
+
+					img {
+						mix-blend-mode: multiply;
+					}
+
+					.entry-meta {
+						opacity: 1;
+						transition: opacity 0.3s ease-in-out;
+					}
+				}
+
+				.entry-meta {
+					opacity: 0;
+					color: var(--wp--preset--color--white);
+					position: absolute;
+					top: 0;
+					left: 0;
+					right: 0;
+					bottom: 0;
+					z-index: 1;
+					display: flex;
+					flex-direction: column;
+					justify-content: flex-end;
+				}
+			}
 		}
 
 
@@ -156,10 +191,11 @@ body.category-community {
 
 			@include break-small() {
 				min-height: 0;
+
 				&:nth-of-type(even):hover,
 				&:nth-of-type(odd):hover {
 					transition: all 0.3s ease-in-out;
-					background-color: black;
+					background-color: var(--wp--preset--color--black);
 				}
 			}
 
@@ -174,44 +210,6 @@ body.category-community {
 				background-color: var(--wp--preset--color--blue-2);
 				color: var(--wp--preset--color--white);
 				vertical-align: bottom;
-			}
-		}
-		// Featured image only for posts that have one
-		&.has-post-thumbnail {
-			position: relative;
-
-			@include break-small() {
-				&:hover,
-				&:focus-within {
-					
-					figure {
-						transition: all 0.3s ease-in-out;
-						background-color: var(--wp--preset--color--blue-1);
-					}
-	
-					img {
-						mix-blend-mode: multiply;
-					}
-
-					.entry-meta {
-						opacity: 1;
-						transition: opacity 0.3s ease-in-out;
-					}
-				}
-
-				.entry-meta {
-					opacity: 0;
-					color: white;
-					position: absolute;
-					top: 0;
-					left: 0;
-					right: 0;
-					bottom: 0;
-					z-index: 1;
-					display: flex;
-					flex-direction: column;
-					justify-content: flex-end;
-				}
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -87,6 +87,16 @@ body.category-security {
 body.category-community {
 
 	@extend %local-header-lightish;
+	//.wp-site-blocks > :not(.site-header-container):not(.local-header):not(.global-footer):not(.footer-archive)
+
+	.wp-site-blocks  > .site-content-container:not(.site-header-container):not(.local-header):not(.global-footer):not(.footer-archive) {
+		padding: 0;
+		margin-top: 0;
+		@include break-small() {
+			padding-left: var(--wp--custom--alignment--edge-spacing);
+			padding-right: var(--wp--custom--alignment--edge-spacing);
+		}
+	}
 
 	.wp-block-post-template {
 		gap: 2px;
@@ -108,8 +118,15 @@ body.category-community {
 	}
 
 	li.post {
-		aspect-ratio: 1 / 1;
 		margin: 0;
+
+		@include break-small() {
+			aspect-ratio: 1 / 1;
+		}
+
+		.entry-meta {
+			padding: 24px;
+		}
 
 		&.has-post-thumbnail {
 			.wp-block-template-part,
@@ -117,7 +134,9 @@ body.category-community {
 			figure,
 			figure a,
 			img {
-				height: 100%;
+				@include break-small() {
+					height: 100%;
+				}
 			}
 			// B&W featured image
 			.wp-block-post-featured-image {
@@ -128,9 +147,13 @@ body.category-community {
 
 		
 		&:not(.has-post-thumbnail) {
-			padding: 24px;
+			min-height: 80vh;
 			display: flex;
 			align-items: flex-end;
+
+			@include break-small() {
+				min-height: 0;
+			}
 			
 			// Alternating blue-1 and blue-2 for non-thumbnail posts
 			&:nth-of-type(even) {
@@ -146,9 +169,10 @@ body.category-community {
 			}
 		}
 		// Featured image only for posts that have one
-		&.has-post-thumbnail .wp-block-post-title,
 		&.has-post-thumbnail .entry-meta {
-			display: none;
+			@include break-small() {
+				display: none;
+			}
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -140,8 +140,11 @@ body.category-community {
 			}
 			// B&W featured image
 			.wp-block-post-featured-image {
-				filter: grayscale(100%);
 				object-fit: cover;
+
+				img {
+					filter: grayscale(100%);
+				}
 			}
 		}
 
@@ -153,6 +156,11 @@ body.category-community {
 
 			@include break-small() {
 				min-height: 0;
+				&:nth-of-type(even):hover,
+				&:nth-of-type(odd):hover {
+					transition: all 0.3s ease-in-out;
+					background-color: black;
+				}
 			}
 
 			// Alternating blue-1 and blue-2 for non-thumbnail posts
@@ -169,10 +177,40 @@ body.category-community {
 			}
 		}
 		// Featured image only for posts that have one
-		&.has-post-thumbnail .entry-meta {
+		&.has-post-thumbnail {
+			position: relative;
 
 			@include break-small() {
-				display: none;
+				&:hover {
+					
+					figure {
+						transition: all 0.3s ease-in-out;
+						background-color: var(--wp--preset--color--blue-1);
+					}
+	
+					img {
+						mix-blend-mode: multiply;
+					}
+
+					.entry-meta {
+						opacity: 1;
+						transition: opacity 0.3s ease-in-out;
+					}
+				}
+
+				.entry-meta {
+					opacity: 0;
+					color: white;
+					position: absolute;
+					top: 0;
+					left: 0;
+					right: 0;
+					bottom: 0;
+					z-index: 1;
+					display: flex;
+					flex-direction: column;
+					justify-content: flex-end;
+				}
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -181,7 +181,8 @@ body.category-community {
 			position: relative;
 
 			@include break-small() {
-				&:hover {
+				&:hover,
+				&:focus-within {
 					
 					figure {
 						transition: all 0.3s ease-in-out;

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -25,8 +25,3 @@ body.page .site-content-container .wp-block-post-content {
 
 	@extend %two-column-grid-container-dynamic-rows;
 }
-
-body.category-community .site-content-container {
-
-	@extend %four-column-grid-container;
-}


### PR DESCRIPTION
Partially addresses #148

This adds some starting styles to the Community category page

Desktop:

![Screenshot 2022-01-14 at 12-43-12 Community – wporg-news-2021](https://user-images.githubusercontent.com/3593343/149510378-4f41e6b2-0ed5-4128-a1be-a3b6125939d6.png)

Mobile:

![Screenshot 2022-01-14 at 12-43-20 Community – wporg-news-2021](https://user-images.githubusercontent.com/3593343/149510370-bfb133b0-8e89-45c9-9bd4-25b1e90f4e50.png)