### PR TITLE
Remove the incorrect dash from heading tags in styles

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-title.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-title.scss
@@ -11,6 +11,6 @@
 	}
 
 	.wp-block-query & {
-		font-size: var(--wp--custom--h-2--typography--font-size);
+		font-size: var(--wp--custom--h2--typography--font-size);
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/elements/_headings.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/elements/_headings.scss
@@ -1,8 +1,8 @@
 .editor-post-title .editor-post-title__input {
 	font-family: var(--wp--custom--heading--typography--font-family);
-	font-size: var(--wp--custom--h-1--typography--font-size);
-	font-weight: var(--wp--custom--h-1--typography--font-weight);
-	line-height: var(--wp--custom--h-1--typography--line-height);
+	font-size: var(--wp--custom--h1--typography--font-size);
+	font-weight: var(--wp--custom--h1--typography--font-weight);
+	line-height: var(--wp--custom--h1--typography--line-height);
 }
 
 @include break-mobile {
@@ -13,13 +13,13 @@
 	 */
 
 	body {
-		--wp--custom--h-1--typography--font-size: var(--wp--custom--h-1--breakpoint--mobile--typography--font-size);
-		--wp--custom--h-1--typography--line-height: var(--wp--custom--h-1--breakpoint--mobile--typography--line-height);
-		--wp--custom--h-2--typography--font-size: var(--wp--custom--h-2--breakpoint--mobile--typography--font-size);
-		--wp--custom--h-3--typography--font-size: var(--wp--custom--h-3--breakpoint--mobile--typography--font-size);
-		--wp--custom--h-3--typography--line-height: var(--wp--custom--h-3--breakpoint--mobile--typography--line-height);
-		--wp--custom--h-4--typography--font-size: var(--wp--custom--h-4--breakpoint--mobile--typography--font-size);
-		--wp--custom--h-5--typography--font-size: var(--wp--custom--h-5--breakpoint--mobile--typography--font-size);
-		--wp--custom--h-5--typography--line-height: var(--wp--custom--h-5--breakpoint--mobile--typography--line-height);
+		--wp--custom--h1--typography--font-size: var(--wp--custom--h1--breakpoint--mobile--typography--font-size);
+		--wp--custom--h1--typography--line-height: var(--wp--custom--h1--breakpoint--mobile--typography--line-height);
+		--wp--custom--h2--typography--font-size: var(--wp--custom--h2--breakpoint--mobile--typography--font-size);
+		--wp--custom--h3--typography--font-size: var(--wp--custom--h3--breakpoint--mobile--typography--font-size);
+		--wp--custom--h3--typography--line-height: var(--wp--custom--h3--breakpoint--mobile--typography--line-height);
+		--wp--custom--h4--typography--font-size: var(--wp--custom--h4--breakpoint--mobile--typography--font-size);
+		--wp--custom--h5--typography--font-size: var(--wp--custom--h5--breakpoint--mobile--typography--font-size);
+		--wp--custom--h5--typography--line-height: var(--wp--custom--h5--breakpoint--mobile--typography--line-height);
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -521,8 +521,8 @@
 			"core/post-title": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
-					"fontSize": "var(--wp--custom--h-1--typography--font-size)",
-					"lineHeight": "var(--wp--custom--h-1--typography--line-height)"
+					"fontSize": "var(--wp--custom--h1--typography--font-size)",
+					"lineHeight": "var(--wp--custom--h1--typography--line-height)"
 				}
 			},
 			"core/pullquote": {
@@ -579,49 +579,49 @@
 			"h1": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
-					"fontSize": "var(--wp--custom--h-1--typography--font-size)",
+					"fontSize": "var(--wp--custom--h1--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--h-1--typography--line-height)"
+					"lineHeight": "var(--wp--custom--h1--typography--line-height)"
 				}
 			},
 			"h2": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
-					"fontSize": "var(--wp--custom--h-2--typography--font-size)",
+					"fontSize": "var(--wp--custom--h2--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--h-2--typography--line-height)"
+					"lineHeight": "var(--wp--custom--h2--typography--line-height)"
 				}
 			},
 			"h3": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
-					"fontSize": "var(--wp--custom--h-3--typography--font-size)",
+					"fontSize": "var(--wp--custom--h3--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--h-3--typography--line-height)"
+					"lineHeight": "var(--wp--custom--h3--typography--line-height)"
 				}
 			},
 			"h4": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
-					"fontSize": "var(--wp--custom--h-4--typography--font-size)",
+					"fontSize": "var(--wp--custom--h4--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--h-4--typography--line-height)"
+					"lineHeight": "var(--wp--custom--h4--typography--line-height)"
 				}
 			},
 			"h5": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
-					"fontSize": "var(--wp--custom--h-5--typography--font-size)",
+					"fontSize": "var(--wp--custom--h5--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--h-5--typography--line-height)"
+					"lineHeight": "var(--wp--custom--h5--typography--line-height)"
 				}
 			},
 			"h6": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
-					"fontSize": "var(--wp--custom--h-6--typography--font-size)",
+					"fontSize": "var(--wp--custom--h6--typography--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--h-6--typography--line-height)"
+					"lineHeight": "var(--wp--custom--h6--typography--line-height)"
 				}
 			},
 			"link": {


### PR DESCRIPTION
While working on https://github.com/WordPress/wporg-news-2021/issues/148 I have discovered an oddity. For some reason the CSS variables would include heading tags with a dash in the middle: `h-1` - that's confusing and causes issues.

I have now removed all 'middle dashes'.