### PR TITLE
Local Header: Add Top-Border to Dark Variant

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_local-header.scss
@@ -284,8 +284,10 @@
 
 		.local-header {
 			--bar-background-color: var(--wp--preset--color--dark-grey);
-			--bar-link-color: var(--off-white);
-			--bar-link-hover-color: var(--off-white-2);
+			--bar-link-color: var(--wp--preset--color--off-white);
+			--bar-link-hover-color: var(--wp--preset--color--off-white-2);
+
+			border-top: 1px solid var(--wp--preset--color--darker-grey);
 		}
 	}
 }


### PR DESCRIPTION
The "Month in WordPress" category template uses a dark navigation bar, which when paired with the global top bar ends up blending in _too_ much; The current indicator under "News" looks out of place, and generally things feel a little awkward:

<img width="1066" alt="image" src="https://user-images.githubusercontent.com/191598/149571686-02ccf22d-cf9d-4503-9458-2f3c8bf3a641.png">

The design calls for a 1px border, which this PR adds:

<img width="1066" alt="image" src="https://user-images.githubusercontent.com/191598/149571826-da77cef3-ea95-4386-93f0-f1bf02b84523.png">
