### PR TITLE
Fix the background texture under the pagination for the Releases category

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -25,6 +25,17 @@ body.category-releases {
 			color: var(--wp--preset--color--white);
 		}
 
+		.wp-block-query-pagination {
+			line-height: 2.4;
+			padding: 1em 1em 1em 0;
+			background-position: bottom right;
+
+			&::after {
+				background: var(--wp--preset--color--blue-2);
+				z-index: -1;
+			}
+		}
+
 		.wp-block-post-title {
 			--post-title-hover-color: var(--wp--preset--color--white);
 		}


### PR DESCRIPTION
Part of #148

Before:
<img width="1294" alt="Releases_–_wporg-news-2021" src="https://user-images.githubusercontent.com/905781/149605404-754eb604-9f51-4241-84ce-9fbf547260fe.png">

After
<img width="1319" alt="after-3" src="https://user-images.githubusercontent.com/905781/149605372-3ca2a4ff-4c2a-488c-b7a3-55d772aa855d.png">

