### PR TITLE
Front page: Update links to correct destinations

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -20,11 +20,11 @@
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 
-	<!-- wp:html -->
-	<!-- See https://github.com/WordPress/wporg-news-2021/issues/70 -->
-	<div class="wp-block-query-pagination" style="display:flex;">
-		<a href="/page/2" class="wp-block-query-pagination-next">See All Posts</a>
-	</div>
-	<!-- /wp:html -->
+	
+	<!-- wp:paragraph {"className":"front__next-page"} -->
+	<p class="front__next-page">
+		<a href="/page/2">See All Posts</a>
+	</p>
+	<!-- /wp:paragraph -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -20,8 +20,11 @@
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 
-	<!-- wp:query-pagination -->
-		<!-- wp:query-pagination-next {"label":"See All Posts"} /-->
-	<!-- /wp:query-pagination -->
+	<!-- wp:html -->
+	<!-- See https://github.com/WordPress/wporg-news-2021/issues/70 -->
+	<div class="wp-block-query-pagination" style="display:flex;">
+		<a href="/page/2" class="wp-block-query-pagination-next">See All Posts</a>
+	</div>
+	<!-- /wp:html -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
@@ -18,11 +18,10 @@
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 
-	<!-- wp:html -->
-	<!-- See https://github.com/WordPress/wporg-news-2021/issues/70 -->
-	<div class="wp-block-query-pagination" style="display:flex;">
-		<a href="/category/releases/" class="wp-block-query-pagination-next">See All Releases</a>
-	</div>
-	<!-- /wp:html -->
+	<!-- wp:paragraph {"className":"front__next-page"} -->
+	<p class="front__next-page">
+		<a href="/category/releases/">See All Releases</a>
+	</p>
+	<!-- /wp:paragraph -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
@@ -18,8 +18,11 @@
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 
-	<!-- wp:query-pagination -->
-		<!-- wp:query-pagination-next {"label":"See All Releases"} /-->
-	<!-- /wp:query-pagination -->
+	<!-- wp:html -->
+	<!-- See https://github.com/WordPress/wporg-news-2021/issues/70 -->
+	<div class="wp-block-query-pagination" style="display:flex;">
+		<a href="/category/releases/" class="wp-block-query-pagination-next">See All Releases</a>
+	</div>
+	<!-- /wp:html -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -10,8 +10,11 @@
 		<!-- wp:post-title {"level":3,"isLink":true,"className":"screen-reader-text"} /-->
 	<!-- /wp:post-template -->
 
-	<!-- wp:query-pagination {"layout":"inherit"} -->
-		<!-- wp:query-pagination-next {"label":"See all people"} /-->
-	<!-- /wp:query-pagination -->
+	<!-- wp:html -->
+	<!-- See https://github.com/WordPress/wporg-news-2021/issues/70 -->
+	<div class="wp-block-query-pagination" style="display:flex;">
+		<a href="/tag/people-of-wordpress/" class="wp-block-query-pagination-next">See All People</a>
+	</div>
+	<!-- /wp:html -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -10,11 +10,10 @@
 		<!-- wp:post-title {"level":3,"isLink":true,"className":"screen-reader-text"} /-->
 	<!-- /wp:post-template -->
 
-	<!-- wp:html -->
-	<!-- See https://github.com/WordPress/wporg-news-2021/issues/70 -->
-	<div class="wp-block-query-pagination" style="display:flex;">
-		<a href="/tag/people-of-wordpress/" class="wp-block-query-pagination-next">See All People</a>
-	</div>
-	<!-- /wp:html -->
+	<!-- wp:paragraph {"className":"front__next-page"} -->
+	<p class="front__next-page">
+		<a href="/tag/people-of-wordpress/">See All People</a>
+	</p>
+	<!-- /wp:paragraph -->
 </section>
 <!-- /wp:query -->

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_front-page.scss
@@ -45,7 +45,7 @@
 		}
 	}
 
-	> .wp-block-query-pagination {
+	.front__next-page {
 		margin-top: 0;
 
 		@include break-wide() {
@@ -106,6 +106,47 @@ body.news-front-page {
 
 		> .wp-block-template-part {
 			margin-top: 0;
+		}
+	}
+
+	.front__next-page {
+		display: flex;
+		color: var(--wp--preset--color--blue-1);
+		position: relative;
+		padding: 40px 0;
+		line-height: normal;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			right: 0;
+			left: 0;
+			z-index: 1;
+			background-color: var(--wp--preset--color--off-white-2);
+			mask-image: url(images/brush-stroke-short-blue-4.svg);
+			mask-position: bottom left;
+			mask-repeat: no-repeat;
+			mask-size: contain;
+
+			@include break-wide() {
+				bottom: 0;
+				left: -50px;
+			}
+		}
+
+		a {
+			z-index: 2;
+		}
+
+		@include break-small-only() {
+			display: flex;
+			justify-content: center;
+
+			&::after {
+				mask-position: center;
+			}
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_latest-release.scss
@@ -34,7 +34,7 @@ body.news-front-page .front__latest-release {
 		}
 	}
 
-	.wp-block-query-pagination {
+	.front__next-page {
 
 		@include break-wide() {
 			border-right: 1px solid var(--wp--preset--color--blue-2);

--- a/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/front-page/_people-of-wordpress.scss
@@ -75,7 +75,7 @@ body.news-front-page .front__people-of-wordpress {
 		}
 	}
 
-	.wp-block-query-pagination {
+	.front__next-page {
 		margin-top: 0;
 
 		a {


### PR DESCRIPTION
This uses the HTML block instead of pagination, because they're not technically pagination— it shouldn't paginate this query, it should go to a new page. I've left the markup the same (using `wp-block-query-pagination` for the class) to avoid CSS changes for now.

Supersedes #126, Fixes #70.

**To test:**

View the front page, and check the following links:
- The "All Posts" link goes to `/page/2/`, and shows the second page of posts
- The "All Releases" link goes to `/category/releases/` and shows the list of releases
- The "All People" link goes to `/tag/people-of-wordpress/` and shows the list of people

We had a discussion about the "See All People" link destination [here](https://github.com/WordPress/wporg-news-2021/issues/115#issuecomment-993745600), but it wasn't resolved - I've left it linking to the People of WordPress tag, since that's what this query block uses.