### PR TITLE
Add dropcap to categories pages

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-templates/category.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category.html
@@ -2,6 +2,13 @@
 
 <!-- wp:query {"tagName":"main","className":"site-content-container"} -->
 <main class="wp-block-query site-content-container">
+
+	<!-- wp:group {"className":"query-title-banner__title__dropcap"} -->
+	<div class="query-title-banner__title__dropcap">
+		<!-- wp:query-title {"type":"archive"} /-->
+	</div>
+	<!-- /wp:group -->
+
 	<!-- wp:post-template -->
 		<!-- wp:template-part {"slug":"content-posts-index","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -303,17 +303,19 @@ body {
 		width: calc(var(--wp--custom--layout--content-meta-size) - 32px) !important;
 
 		.wp-block-query-title {
-			color: var(--category-color); 
+			color: var(--category-color);
 			font-size: 0;
 			line-height: 0.7;
+
 			@include hide-accessibly;
 
 			@include break-wide() {
+
 				@include show-hidden-accessibly;
-				margin-top: var( --wp--style--block-gap );
+				margin-top: var(--wp--style--block-gap);
 			}
 
-			&:first-letter {
+			&::first-letter {
 				font-size: 35vw;
 				text-transform: uppercase;
 			}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_categories.scss
@@ -125,19 +125,23 @@ body.category-month-in-wordpress {
 
 body.category-development {
 
+	--category-color: var(--wp--preset--color--green);
+
 	@extend %local-header-lightish;
 
 	.local-header {
-		--bar-background-color: var(--wp--preset--color--green);
+		--bar-background-color: var(--category-color);
 	}
 }
 
 body.category-security {
 
+	--category-color: var(--wp--preset--color--coral-red);
+
 	@extend %local-header-lightish;
 
 	.local-header {
-		--bar-background-color: var(--wp--preset--color--coral-red);
+		--bar-background-color: var(--category-color);
 	}
 }
 
@@ -288,4 +292,31 @@ body.category-community {
 		}
 	}
 
+}
+
+body {
+
+	--category-color: var(--wp--preset--color--blue-1);
+
+	.query-title-banner__title__dropcap {
+		grid-column: 1 !important;
+		width: calc(var(--wp--custom--layout--content-meta-size) - 32px) !important;
+
+		.wp-block-query-title {
+			color: var(--category-color); 
+			font-size: 0;
+			line-height: 0.7;
+			@include hide-accessibly;
+
+			@include break-wide() {
+				@include show-hidden-accessibly;
+				margin-top: var( --wp--style--block-gap );
+			}
+
+			&:first-letter {
+				font-size: 35vw;
+				text-transform: uppercase;
+			}
+		}
+	}
 }


### PR DESCRIPTION
I'm not sure if this is tracked somewhere but I've seen there's a dropcap in the design of category pages, so I went ahead and implemented it:

<img width="1423" alt="Screenshot 2022-01-20 at 11 40 34" src="https://user-images.githubusercontent.com/3593343/150323555-99eee4fc-b0b9-4743-b854-962de1df0fa0.png">

<img width="1409" alt="Screenshot 2022-01-20 at 11 39 33" src="https://user-images.githubusercontent.com/3593343/150323561-19783e13-e91c-42c3-b35d-5ceaea500053.png">

<img width="1401" alt="Screenshot 2022-01-20 at 11 39 26" src="https://user-images.githubusercontent.com/3593343/150323566-d6c6fe0e-0901-4512-9a86-6abf130da5f8.png">

