### PR TITLE
Blockquote: spacing + full width alignment fixes

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_pullquote.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_pullquote.scss
@@ -9,6 +9,8 @@
 	background-size: contain;
 	font-size: 40px;
 	text-align: var(--wp--custom--pullquote--typography--text-align);
+	margin-top: calc( var(--wp--custom--margin--vertical) * 1.333);
+	margin-bottom: calc( var(--wp--custom--margin--vertical) * 3);
 
 	&.alignfull {
 		background-position: -45px 0;

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_pullquote.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_pullquote.scss
@@ -6,11 +6,15 @@
 	background-image: url(./images/quotemark.svg);
 	background-repeat: no-repeat;
 	background-position: top left;
-	background-size: contain;
+	background-size: 200px auto;
 	font-size: 40px;
 	text-align: var(--wp--custom--pullquote--typography--text-align);
 	margin-top: calc( var(--wp--custom--margin--vertical) * 1.333);
 	margin-bottom: calc( var(--wp--custom--margin--vertical) * 3);
+
+	@include break-small {
+		background-size: contain;
+	}
 
 	&.alignfull {
 		background-position: -45px 0;
@@ -44,6 +48,7 @@
 			font-style: var(--wp--custom--pullquote--citation--typography--font-style);
 			font-family: var(--wp--custom--pullquote--citation--typography--font-family);
 			margin-top: var(--wp--custom--pullquote--citation--spacing--margin--top);
+			color: var(--wp--preset--color--blue-1); 
 
 			&::before {
 				content: "—";

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_pullquote.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_pullquote.scss
@@ -9,8 +9,8 @@
 	background-size: 200px auto;
 	font-size: 40px;
 	text-align: var(--wp--custom--pullquote--typography--text-align);
-	margin-top: calc( var(--wp--custom--margin--vertical) * 1.333);
-	margin-bottom: calc( var(--wp--custom--margin--vertical) * 3);
+	margin-top: calc(var(--wp--custom--margin--vertical) * 1.333);
+	margin-bottom: calc(var(--wp--custom--margin--vertical) * 3);
 
 	@include break-small {
 		background-size: contain;
@@ -48,7 +48,7 @@
 			font-style: var(--wp--custom--pullquote--citation--typography--font-style);
 			font-family: var(--wp--custom--pullquote--citation--typography--font-family);
 			margin-top: var(--wp--custom--pullquote--citation--spacing--margin--top);
-			color: var(--wp--preset--color--blue-1); 
+			color: var(--wp--preset--color--blue-1);
 
 			&::before {
 				content: "—";

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -17,9 +17,9 @@
 	}
 
 	.wp-block-pullquote {
-		grid-column: 1 / span 2;
-		width: 100%;
-		max-width: 100%;
+		grid-column: 1 / span 2 !important;
+		width: 100% !important;
+		max-width: 100% !important;
 	}
 }
 

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -15,6 +15,12 @@
 			margin-top: 0;
 		}
 	}
+
+	.wp-block-pullquote {
+		grid-column: 1 / span 2;
+		width: 100%;
+		max-width: 100%;
+	}
 }
 
 body.news-posts-index .site-content-container,


### PR DESCRIPTION
Closes https://github.com/WordPress/wporg-news-2021/issues/141

I also changed the color of the cite and the size of the quotes on mobile to fit the design.

<img width="1529" alt="Screenshot 2022-01-20 at 12 48 06" src="https://user-images.githubusercontent.com/3593343/150333329-9c54179a-23cf-47ff-8d81-1939ea52e46d.png">

