### PR TITLE
Fixing the query-title so it doesn't cause issues with the local-header.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/query-title-banner.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/query-title-banner.html
@@ -2,12 +2,12 @@
   -- @link https://github.com/WordPress/gutenberg/issues/33476
   -- @link https://github.com/WordPress/gutenberg/issues/36268
   -->
-  <!-- wp:query-title {"type":"archive","level":1,"className":"query-title-banner__query-title"} /-->
+<!-- wp:query-title {"type":"archive","level":1,"className":"query-title-banner__query-title"} /-->
 
-  <!-- wp:heading {"level":1,"className":"query-title-banner__all-posts"} -->
-  <h1 class="wp-block-query-title query-title-banner__all-posts">All Posts</h1>
-  <!-- /wp:heading -->
+<!-- wp:heading {"level":1,"className":"query-title-banner__all-posts"} -->
+<h1 class="wp-block-query-title query-title-banner__all-posts">All Posts</h1>
+<!-- /wp:heading -->
 
-  <!-- wp:heading {"level":1,"className":"query-title-banner__search-results"} -->
-  <h1 class="wp-block-query-title query-title-banner__search-results">Search Results</h1>
-  <!-- /wp:heading -->
+<!-- wp:heading {"level":1,"className":"query-title-banner__search-results"} -->
+<h1 class="wp-block-query-title query-title-banner__search-results">Search Results</h1>
+<!-- /wp:heading -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/query-title-banner.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/query-title-banner.html
@@ -2,12 +2,12 @@
   -- @link https://github.com/WordPress/gutenberg/issues/33476
   -- @link https://github.com/WordPress/gutenberg/issues/36268
   -->
-<!-- wp:query-title {"type":"archive","level":1,"className":"query-title-banner__title"} /-->
+  <!-- wp:query-title {"type":"archive","level":1,"className":"query-title-banner__query-title"} /-->
 
-<!-- wp:heading {"level":1} -->
-<h1 class="wp-block-query-title query-title-banner__title-all-posts">All Posts</h1>
-<!-- /wp:heading -->
+  <!-- wp:heading {"level":1,"className":"query-title-banner__all-posts"} -->
+  <h1 class="wp-block-query-title query-title-banner__all-posts">All Posts</h1>
+  <!-- /wp:heading -->
 
-<!-- wp:heading {"level":1} -->
-<h1 class="wp-block-query-title query-title-banner__title-search-results">Search Results</h1>
-<!-- /wp:heading -->
+  <!-- wp:heading {"level":1,"className":"query-title-banner__search-results"} -->
+  <h1 class="wp-block-query-title query-title-banner__search-results">Search Results</h1>
+  <!-- /wp:heading -->

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
@@ -1,10 +1,10 @@
 .query-title-banner {
-  padding: var(--wp--custom--alignment--edge-spacing);
-  color: var(--wp--preset--color--white);
+	padding: var(--wp--custom--alignment--edge-spacing);
+	color: var(--wp--preset--color--white);
 	position: relative;
-  z-index: -1;
+	z-index: -1;
 	background: linear-gradient(to top, transparent 58px, var(--wp--preset--color--blue-1) 58px 100%);
-  transform: translateY(-80px);
+	transform: translateY(-80px);
 
 	&::after {
 		content: "";
@@ -21,9 +21,9 @@
 		background-color: var(--wp--preset--color--blue-1);
 	}
 
-  .wp-block-query-title {
-    font-size: clamp(20px, calc( 100vw / 12 ), 120px);
-  }
+	.wp-block-query-title {
+		font-size: clamp(20px, calc(100vw / 12), 120px);
+	}
 }
 
 // Hide the banner by default
@@ -42,9 +42,9 @@ body.search .query-title-banner__search-results {
 
 // Setup the basic two-column layout;
 .site-index {
-  margin: var(--wp--custom--alignment--edge-spacing);
+	margin: var(--wp--custom--alignment--edge-spacing);
 
-  @include break-large() {
-    padding-left: var(--wp--custom--layout--content-meta-size);
-  }
+	@include break-large() {
+		padding-left: var(--wp--custom--layout--content-meta-size);
+	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
@@ -1,49 +1,50 @@
 .query-title-banner {
-	background-color: var(--wp--preset--color--blue-1);
-	margin-top: 0;
+  padding: var(--wp--custom--alignment--edge-spacing);
+  color: var(--wp--preset--color--white);
+	position: relative;
+  z-index: -1;
+	background: linear-gradient(to top, transparent 58px, var(--wp--preset--color--blue-1) 58px 100%);
+  transform: translateY(-80px);
 
-	.wp-block-query-title {
-
-		/*
-		 * Hide all of them by default because there are 3 of them, but only one should be shown at a time.
-		 * See `query-title-banner.html` for details.
-		 */
-		display: none;
-
-		font-size: 7.5rem;
-		color: var(--wp--preset--color--white);
-		padding-bottom: 0.5em;
+	&::after {
+		content: "";
+		min-height: 58px;
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		z-index: -1;
+		mask-image: url(images/local-nav-mask.svg);
+		mask-repeat: no-repeat;
+		mask-size: cover;
+		mask-position: 0;
+		background-color: var(--wp--preset--color--blue-1);
 	}
+
+  .wp-block-query-title {
+    font-size: clamp(20px, calc( 100vw / 12 ), 120px);
+  }
 }
 
-body.archive .query-title-banner__title,
-body.news-posts-index .query-title-banner__title-all-posts,
-body.search .query-title-banner__title-search-results {
+// Hide the banner by default
+.query-title-banner__query-title,
+.query-title-banner__all-posts,
+.query-title-banner__search-results {
+	display: none;
+}
+
+// Show the relevant banner based on the body class.
+body.archive .query-title-banner__query-title,
+body.news-posts-index .query-title-banner__all-posts,
+body.search .query-title-banner__search-results {
 	display: block;
 }
 
-body.news-front-page,
-body.news-posts-index,
-body.search,
-body.archive:not(.category) {
-	--bar-background-color: var(--wp--preset--color--blue-1);
+// Setup the basic two-column layout;
+.site-index {
+  margin: var(--wp--custom--alignment--edge-spacing);
 
-	.local-header {
-
-		/* Add a background to hide the mask when menu is not open so it blends with `query-title-banner`. */
-		&::before {
-			content: "";
-			position: absolute;
-			height: 56px;
-			top: 0;
-			left: 0;
-			right: 0;
-			background-color: var(--bar-background-color);
-		}
-	}
-
-	.query-title-banner {
-
-		@extend %bottom-mask;
-	}
+  @include break-large() {
+    padding-left: var(--wp--custom--layout--content-meta-size);
+  }
 }


### PR DESCRIPTION
There's some weird stuff that happens with the query-title-banner CSS which causes issues like this:

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/191598/150591587-e357b323-7fdc-4e1d-8313-864835eb2b69.png">

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/191598/150591651-0188c563-2c98-4e1d-b593-e2594b746514.png">

This PR rewrites things to avoid these issues:

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/191598/150591704-21f8371e-4b8a-4976-b25e-e8b3098ec9aa.png">

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/191598/150591721-066a681b-7a28-491c-9354-c137c46e4662.png">
