### PR TITLE
Reducing the thickness of link underlines.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/elements/_links.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/elements/_links.scss
@@ -1,8 +1,9 @@
 // Default link styles
 a {
 	cursor: pointer;
-	text-underline-offset: 0.15em;
 	text-decoration: none;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
 
 	&:hover,
 	&:focus {


### PR DESCRIPTION
Right now link underlines are based on the font-size, which can lead to some awkward looks:

<img width="693" alt="image" src="https://user-images.githubusercontent.com/191598/150597823-34c8b7d3-9f8d-4039-8881-a6835a2ae105.png">

This PR reduces them down to a single pixel everywhere:

<img width="666" alt="image" src="https://user-images.githubusercontent.com/191598/150597879-8b661413-0c21-4676-a563-6376a3816743.png">
