### PR TITLE
Categories archives: Hide the decorative archive title from screen readers

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-templates/category.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category.html
@@ -4,7 +4,7 @@
 <main class="wp-block-query site-content-container">
 
 	<!-- wp:group {"className":"query-title-banner__title__dropcap"} -->
-	<div class="query-title-banner__title__dropcap" aria-hidden>
+	<div class="query-title-banner__title__dropcap" aria-hidden="true">
 		<!-- wp:query-title {"type":"archive"} /-->
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category.html
@@ -4,7 +4,7 @@
 <main class="wp-block-query site-content-container">
 
 	<!-- wp:group {"className":"query-title-banner__title__dropcap"} -->
-	<div class="query-title-banner__title__dropcap">
+	<div class="query-title-banner__title__dropcap" aria-hidden>
 		<!-- wp:query-title {"type":"archive"} /-->
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -313,17 +313,17 @@ body {
 	.query-title-banner__title__dropcap {
 		grid-column: 1 !important;
 		width: calc(var(--wp--custom--layout--content-meta-size) - 32px) !important;
+		user-select: none;
 
 		.wp-block-query-title {
 			color: var(--category-color);
 			font-size: 0;
 			line-height: 0.7;
-
-			@include hide-accessibly;
+			display: none;
 
 			@include break-wide() {
 
-				@include show-hidden-accessibly;
+				display: block;
 				margin-top: var(--wp--style--block-gap);
 			}
 


### PR DESCRIPTION
This prevents a double level-1 heading from appearing on the page, which can be confusing/incorrect for screen reader users.

Fixes #211

This is a bit of a hack — to hide this content from screen readers but not visually, I need to add the `aria-hidden` attribute to the `div` container. As far as I can tell, there's no way to do this in plain CSS. Adding the attribute to the group block works, but if this template is edited in the site editor it will be wiped out. Since the editor is broken anyway, this is probably okay _for now_, but an alternate solution will be needed.

Screenshots:
There should be no visual change:

![cat-m](https://user-images.githubusercontent.com/541093/150651856-a9d9e133-6db6-4cbe-a371-26f150419a9f.png)

![cat-s](https://user-images.githubusercontent.com/541093/150651857-f1f69626-d1da-452c-82d6-7e77fb9cd4c9.png)

I also tried adding a category in Korean to see how this will handle non-Latin characters, and it's okay— the character breaks out of the container a bit - so if/when this theme is used on rosetta sites we'll need to address that (i'm sure it won't be the only thing). I am impressed that the CSS `first-letter` algorithm understands what to do here, and if we tried to implement our own solution in PHP (my only other idea), we'd need to be just as thorough.
![cat-han](https://user-images.githubusercontent.com/541093/150651855-09fe4325-67f3-4464-95a8-3c7510bb21ec.png)

Heading structure

```
1. Security
  2. WordPress 5.7.2 Security Release
  2. WordPress 5.7.1 Security and Maintenance Release
  2. WordPress 5.4.2 Security and Maintenance Release
  2. WordPress 5.4.1
  2. Get the Latest Updates
    3. Follow The Code
    3. Find An Event Near You
    3. Subscribe to WordPress News
    3. WP Briefing — The WordPress Podcast
```

To test:

- View a category page
- At a screen size >1280px wide, you should see the first letter of the category
- Use a screen reader or other tool to get a list of the headings on the page
- There should only be one `h1` heading

