### PR TITLE
Alignments: Add negative margins to .alignfull

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
@@ -32,6 +32,12 @@ a {
 		padding-left: var(--wp--style--block-gap);
 		padding-right: var(--wp--style--block-gap);
 	}
+
+	&.alignfull {
+		figcaption {
+			padding-right: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--style--block-gap));
+		}
+	}
 }
 
 

--- a/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
@@ -75,7 +75,7 @@
 		&.alignfull {
 			
 			width: auto;
-			max-width: auto;
+			max-width: none;
 			margin-left: calc( -1 * var(--wp--custom--alignment--edge-spacing) ) !important;
 			margin-right: calc( -1 * var(--wp--custom--alignment--edge-spacing) ) !important;
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
@@ -71,6 +71,14 @@
 				max-width: 100%;
 			}
 		}
+
+		&.alignfull {
+			
+			width: auto;
+			max-width: auto;
+			margin-left: calc( -1 * var(--wp--custom--alignment--edge-spacing) ) !important;
+			margin-right: calc( -1 * var(--wp--custom--alignment--edge-spacing) ) !important;
+		}
 	}
 }
 


### PR DESCRIPTION
This is a potential fix for #231. I've added negative margins to `alignfull` which have the same width as the left and right padding for `entry-content`. This means anything that is set to `alignfull` should stretch to the edges:

![image](https://user-images.githubusercontent.com/1645628/150773853-55600845-030d-4276-9ee2-51f775ed5fe0.png)

Is this the intended style for `alignfull`?

Closes #231