### PR TITLE
Homepage: Fix horizontal scrolling

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
@@ -26,7 +26,7 @@ body.news-front-page {
 			top: calc(35% - 65px);
 			left: 180px;
 			height: 130px;
-			width: 100vw;
+			width: calc(100vw - 180px);
 			z-index: -1;
 			background-color: var(--wp--preset--color--blue-2);
 			mask-image: url(images/brush-stroke-big.svg);

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -90,12 +90,13 @@ body.news-front-page .front__people-of-wordpress {
 	.front__next-page {
 		font-size: var(--wp--preset--font-size--small);
 		padding: var(--wp--custom--alignment--edge-spacing);
+		width: 192px;
 
 		@include break-medium() {
-			padding: 0;
+			padding: 0 var(--wp--custom--alignment--edge-spacing) 0 0;
 			position: absolute;
 			top: var(--wp--custom--alignment--edge-spacing);
-			right: var(--wp--custom--alignment--edge-spacing);
+			right: 0;
 
 			&::before {
 				content: "";


### PR DESCRIPTION
This reduces the width of the homepage `h1`, and also slightly refactors the 'See All People' link so that it doesn't cause a horizontal scroll bar.

Closes #224.