### PR TITLE
Page Template: Add edge spacing padding to pages

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/post/_single.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_single.scss
@@ -1,4 +1,5 @@
-body.single {
+body.single,
+body.page {
 	.entry-header,
 	.wp-block-post-content {
 		padding-left: var(--wp--custom--alignment--edge-spacing);


### PR DESCRIPTION
This adds `body.page` to the styling rule that sets the left and right padding to `var(--wp--custom--alignment--edge-spacing)` for posts.

| Before | After |
| ------ | ----- |
|  ![image](https://user-images.githubusercontent.com/1645628/150839719-e61ce9c3-0b88-444a-9d91-e7b242ce716f.png)   |  ![image](https://user-images.githubusercontent.com/1645628/150839614-dcd738de-6223-49b5-982f-7b2c34dfc954.png)    |

Closes #226.