### PR TITLE
Update/pagination control

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
@@ -63,6 +63,7 @@
 			padding: 0 8px;
 		}
 	}
+
 	.wp-block-query-pagination-next {
 		&::before {
 			content: "\00B7";

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
@@ -10,6 +10,7 @@
 
 	body:where(.archive, .blog.paged) & {
 		padding: 40px 0;
+		gap: 0;
 
 		@include break-small-only() {
 			display: flex;
@@ -57,14 +58,14 @@
 	}
 
 	.wp-block-query-pagination-numbers {
-		&::before {
-			content: "\00B7\0020";
-			padding-left: 2px;
+		body[class*="paged-"] &::before {
+			content: "\00B7";
+			padding: 0 8px;
 		}
 
 		&::after {
-			content: "\0020\00B7";
-			padding-right: 2px;
+			content: "\00B7";
+			padding: 0 8px;
 		}
 
 		> * {

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_query-pagination.scss
@@ -57,17 +57,20 @@
 		margin-right: 0;
 	}
 
-	.wp-block-query-pagination-numbers {
-		body[class*="paged-"] &::before {
-			content: "\00B7";
-			padding: 0 8px;
-		}
-
+	.wp-block-query-pagination-previous {
 		&::after {
 			content: "\00B7";
 			padding: 0 8px;
 		}
+	}
+	.wp-block-query-pagination-next {
+		&::before {
+			content: "\00B7";
+			padding: 0 8px;
+		}
+	}
 
+	.wp-block-query-pagination-numbers {
 		> * {
 			display: inline-block;
 			padding: 0 2px;

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -27,6 +27,16 @@ body.category-releases {
 		a:hover {
 			color: var(--wp--preset--color--white);
 		}
+
+		// Make sure the pagination works with the category's
+		// blue background color.
+		.wp-block-query-pagination {
+			color: var(--wp--preset--color--white);
+
+			&:after {
+				background-color: var(--wp--preset--color--blue-5);
+			}
+		}
 	}
 
 	@extend %bottom-banner-dark;

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -33,7 +33,7 @@ body.category-releases {
 		.wp-block-query-pagination {
 			color: var(--wp--preset--color--white);
 
-			&:after {
+			&::after {
 				background-color: var(--wp--preset--color--blue-5);
 			}
 		}


### PR DESCRIPTION
Adjusts the color of text and the brush stroke to work on the blue background of the Releases section (#238):

Before:
<img width="328" alt="image" src="https://user-images.githubusercontent.com/191598/150851280-f942f474-aa90-4638-a58b-240d9cd43655.png">

After:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/191598/150851102-ed1b5991-0622-4dca-8940-87fe86173174.png">

--

Shows the dot between "Newer Posts" and "1 2 3" only when needed, and adjust the overall spacing around the dots:

Before:
<img width="469" alt="image" src="https://user-images.githubusercontent.com/191598/150851457-50fbb918-da18-4f9e-a5c2-a9b47b44ba1e.png">

<img width="275" alt="image" src="https://user-images.githubusercontent.com/191598/150851471-3ba01f57-ab85-482e-a0bb-65b9d75ae880.png">

After:

<img width="442" alt="image" src="https://user-images.githubusercontent.com/191598/150851197-ac7c5623-3e32-4424-bd70-c96d28d1cc60.png">

<img width="280" alt="image" src="https://user-images.githubusercontent.com/191598/150851586-c23c3645-121b-4c70-819d-104de8c97ed1.png">

