### PR TITLE
Pagination: Wrap long post titles onto a new line

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_navigation.scss
@@ -14,6 +14,7 @@
 			@include break-large() {
 				gap: 3ch;
 				flex-direction: row;
+				align-items: center;
 			}
 
 			.post-navigation-link__label {
@@ -33,7 +34,7 @@
 			}
 
 			.post-navigation-link__title {
-				white-space: nowrap;
+				line-height: 1.375;
 			}
 		}
 


### PR DESCRIPTION
Fixes #227 — If post titles are too long, they'll wrap onto a new line. This also changes the line-height of post titles to 1.375 (22px).

<img width="822" alt="Screen Shot 2022-01-24 at 5 14 20 PM" src="https://user-images.githubusercontent.com/541093/150875573-af9242e8-b599-4ff0-af62-9cdb4214ab83.png">

<img width="1046" alt="Screen Shot 2022-01-24 at 5 13 58 PM" src="https://user-images.githubusercontent.com/541093/150875575-cc873356-e1df-46af-819c-50ec36348cf0.png">

I did not build in any truncation - in my testing I didn't see any titles that wrapped to a third line, but if we end up needing that we can revisit the idea.