### PR TITLE
Layout: Stick content to top of page.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
@@ -6,9 +6,11 @@
 	flex-direction: column;
 	margin-top: -(var(--wp-admin--admin-bar--height, 0));
 
-	// Make sure the footer is always at the bottom of the viewport, even on pages with little content.
-	// Otherwise there'd be empty space below the footer
-	justify-content: space-between;
+	> .site-content-container {
+		// Make the content area grow to fill any remaining space on the screen, so that the footer is pushed to
+		// the bottom.
+		margin-bottom: auto;
+	}
 }
 
 // The following "placeholder selectors" define many of the layout-related
@@ -73,7 +75,7 @@
 		}
 
 		&.alignfull {
-			
+
 			width: auto;
 			max-width: none;
 			margin-left: calc( -1 * var(--wp--custom--alignment--edge-spacing) ) !important;


### PR DESCRIPTION
See #223

The previous method of sticking the footer to the bottom had the side-effect of pushing the content down to the middle. This achieves the former without the latter.

<table>
<tr>
<td>before:

![Screen Shot 2022-01-25 at 14 30 07-fullpage](https://user-images.githubusercontent.com/484068/151070656-fdc249f4-455b-4933-9dd1-e8015d410fb9.png)

</td>
<td>after:

![Screen Shot 2022-01-25 at 14 29 56-fullpage](https://user-images.githubusercontent.com/484068/151070687-0d50f2d0-2454-46ca-adab-46c975d122e1.png)

</td>
</tr>