### PR TITLE
Adjust vertical position of query title mask

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
@@ -10,7 +10,7 @@
 		content: "";
 		min-height: 58px;
 		position: absolute;
-		bottom: 0;
+		bottom: 1px;
 		left: 0;
 		right: 0;
 		z-index: -1;


### PR DESCRIPTION
This adjusts the vertical position of the query title mask by 1px, which should remove the grey line which is appearing sometimes at certain resolutions (e.g. 1440px).

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/1645628/151204454-a989f6c6-ca0c-4357-8efd-d1cf59d09da9.png)    |  ![image](https://user-images.githubusercontent.com/1645628/151204749-13c66fc1-3431-4cb0-8f4e-745b8cfaaae8.png)      |

Fixes #248.