### PR TITLE
Modularize components/_local-header.scss

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
@@ -78,8 +78,8 @@
 
 			width: auto;
 			max-width: none;
-			margin-left: calc( -1 * var(--wp--custom--alignment--edge-spacing) ) !important;
-			margin-right: calc( -1 * var(--wp--custom--alignment--edge-spacing) ) !important;
+			margin-left: calc(-1 * var(--wp--custom--alignment--edge-spacing)) !important;
+			margin-right: calc(-1 * var(--wp--custom--alignment--edge-spacing)) !important;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
@@ -1,0 +1,33 @@
+body .wp-site-blocks .local-header {
+    // Breadcrumbs show the lineage of pages based on the current
+	// page. It contains a link for each parent.
+	.local-header__breadcrumb {
+		display: flex;
+		align-items: center;
+		min-height: var(--bar-min-height);
+		color: var(--bar-text-color);
+
+		// The current item is highlighted.
+		&-current {
+			font-family: var(--wp--preset--font-family--inter);
+			font-size: 1rem;
+			font-weight: 700;
+
+			// This ensures that the square separator
+			// is reliably centered.
+			display: flex;
+			align-items: center;
+			margin-top: 0;
+
+			&::before {
+				content: "";
+				height: 2px;
+				width: 2px;
+				background: var(--bar-text-color);
+				display: inline-block;
+				margin: 0 0.5rem;
+				border-radius: 2px;
+			}
+		}
+	}
+}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
@@ -1,31 +1,33 @@
-// Breadcrumbs show the lineage of pages based on the current
-// page. It contains a link for each parent.
-.local-header__breadcrumb {
-    display: flex;
-    align-items: center;
-    min-height: var(--bar-min-height);
-    color: var(--bar-text-color);
-
-    // The current item is highlighted.
-    &-current {
-        font-family: var(--wp--preset--font-family--inter);
-        font-size: 1rem;
-        font-weight: 700;
-
-        // This ensures that the square separator
-        // is reliably centered.
+.local-header {
+    // Breadcrumbs show the lineage of pages based on the current
+    // page. It contains a link for each parent.
+    .local-header__breadcrumb {
         display: flex;
         align-items: center;
-        margin-top: 0;
+        min-height: var(--bar-min-height);
+        color: var(--bar-text-color);
 
-        &::before {
-            content: "";
-            height: 2px;
-            width: 2px;
-            background: var(--bar-text-color);
-            display: inline-block;
-            margin: 0 0.5rem;
-            border-radius: 2px;
+        // The current item is highlighted.
+        &-current {
+            font-family: var(--wp--preset--font-family--inter);
+            font-size: 1rem;
+            font-weight: 700;
+
+            // This ensures that the square separator
+            // is reliably centered.
+            display: flex;
+            align-items: center;
+            margin-top: 0;
+
+            &::before {
+                content: "";
+                height: 2px;
+                width: 2px;
+                background: var(--bar-text-color);
+                display: inline-block;
+                margin: 0 0.5rem;
+                border-radius: 2px;
+            }
         }
     }
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
@@ -1,33 +1,33 @@
 .local-header {
-    // Breadcrumbs show the lineage of pages based on the current
-    // page. It contains a link for each parent.
-    .local-header__breadcrumb {
-        display: flex;
-        align-items: center;
-        min-height: var(--bar-min-height);
-        color: var(--bar-text-color);
+	// Breadcrumbs show the lineage of pages based on the current
+	// page. It contains a link for each parent.
+	.local-header__breadcrumb {
+		display: flex;
+		align-items: center;
+		min-height: var(--bar-min-height);
+		color: var(--bar-text-color);
 
-        // The current item is highlighted.
-        .local-header__breadcrumb-current {
-            font-family: var(--wp--preset--font-family--inter);
-            font-size: 1rem;
-            font-weight: 700;
+		// The current item is highlighted.
+		.local-header__breadcrumb-current {
+			font-family: var(--wp--preset--font-family--inter);
+			font-size: 1rem;
+			font-weight: 700;
 
-            // This ensures that the square separator
-            // is reliably centered.
-            display: flex;
-            align-items: center;
-            margin-top: 0;
+			// This ensures that the square separator
+			// is reliably centered.
+			display: flex;
+			align-items: center;
+			margin-top: 0;
 
-            &::before {
-                content: "";
-                height: 2px;
-                width: 2px;
-                background: var(--bar-text-color);
-                display: inline-block;
-                margin: 0 0.5rem;
-                border-radius: 2px;
-            }
-        }
-    }
+			&::before {
+				content: "";
+				height: 2px;
+				width: 2px;
+				background: var(--bar-text-color);
+				display: inline-block;
+				margin: 0 0.5rem;
+				border-radius: 2px;
+			}
+		}
+	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
@@ -8,7 +8,7 @@
         color: var(--bar-text-color);
 
         // The current item is highlighted.
-        &-current {
+        .local-header__breadcrumb-current {
             font-family: var(--wp--preset--font-family--inter);
             font-size: 1rem;
             font-weight: 700;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
@@ -1,33 +1,33 @@
 body .wp-site-blocks .local-header {
     // Breadcrumbs show the lineage of pages based on the current
-	// page. It contains a link for each parent.
-	.local-header__breadcrumb {
-		display: flex;
-		align-items: center;
-		min-height: var(--bar-min-height);
-		color: var(--bar-text-color);
+    // page. It contains a link for each parent.
+    .local-header__breadcrumb {
+        display: flex;
+        align-items: center;
+        min-height: var(--bar-min-height);
+        color: var(--bar-text-color);
 
-		// The current item is highlighted.
-		&-current {
-			font-family: var(--wp--preset--font-family--inter);
-			font-size: 1rem;
-			font-weight: 700;
+        // The current item is highlighted.
+        &-current {
+            font-family: var(--wp--preset--font-family--inter);
+            font-size: 1rem;
+            font-weight: 700;
 
-			// This ensures that the square separator
-			// is reliably centered.
-			display: flex;
-			align-items: center;
-			margin-top: 0;
+            // This ensures that the square separator
+            // is reliably centered.
+            display: flex;
+            align-items: center;
+            margin-top: 0;
 
-			&::before {
-				content: "";
-				height: 2px;
-				width: 2px;
-				background: var(--bar-text-color);
-				display: inline-block;
-				margin: 0 0.5rem;
-				border-radius: 2px;
-			}
-		}
-	}
+            &::before {
+                content: "";
+                height: 2px;
+                width: 2px;
+                background: var(--bar-text-color);
+                display: inline-block;
+                margin: 0 0.5rem;
+                border-radius: 2px;
+            }
+        }
+    }
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
@@ -1,33 +1,31 @@
-body .wp-site-blocks .local-header {
-    // Breadcrumbs show the lineage of pages based on the current
-    // page. It contains a link for each parent.
-    .local-header__breadcrumb {
+// Breadcrumbs show the lineage of pages based on the current
+// page. It contains a link for each parent.
+.local-header__breadcrumb {
+    display: flex;
+    align-items: center;
+    min-height: var(--bar-min-height);
+    color: var(--bar-text-color);
+
+    // The current item is highlighted.
+    &-current {
+        font-family: var(--wp--preset--font-family--inter);
+        font-size: 1rem;
+        font-weight: 700;
+
+        // This ensures that the square separator
+        // is reliably centered.
         display: flex;
         align-items: center;
-        min-height: var(--bar-min-height);
-        color: var(--bar-text-color);
+        margin-top: 0;
 
-        // The current item is highlighted.
-        &-current {
-            font-family: var(--wp--preset--font-family--inter);
-            font-size: 1rem;
-            font-weight: 700;
-
-            // This ensures that the square separator
-            // is reliably centered.
-            display: flex;
-            align-items: center;
-            margin-top: 0;
-
-            &::before {
-                content: "";
-                height: 2px;
-                width: 2px;
-                background: var(--bar-text-color);
-                display: inline-block;
-                margin: 0 0.5rem;
-                border-radius: 2px;
-            }
+        &::before {
+            content: "";
+            height: 2px;
+            width: 2px;
+            background: var(--bar-text-color);
+            display: inline-block;
+            margin: 0 0.5rem;
+            border-radius: 2px;
         }
     }
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
@@ -1,176 +1,174 @@
-body .wp-site-blocks .local-header {
-    // The Categories button toggles the display of the list
-    // over highlighted categories.
-    .local-header__categories {
+// The Categories button toggles the display of the list
+// over highlighted categories.
+.local-header__categories {
 
-        // The (hidden) checkbox which allows
-        // for toggling the menu on and off.
-        .local-header__categories-toggle {
+    // The (hidden) checkbox which allows
+    // for toggling the menu on and off.
+    .local-header__categories-toggle {
 
-            @include hide-accessibly;
+        @include hide-accessibly;
 
+        + label {
+            // The scrim that covers the content below
+            // with a dark overlay. It's hidden by default.
+            &::before {
+                content: "";
+                display: block;
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100vh;
+                opacity: 0;
+                pointer-events: none;
+                background-color: rgba(0, 0, 0, 0.5);
+                z-index: -1;
+                transition: opacity 0.15s ease-in-out;
+            }
+        }
+
+        // Add focus state around label when input is focused.
+        &:focus + label {
+            outline: 1px dotted currentColor;
+        }
+
+        // When toggled, underline the label, rotate the
+        // icon, fade-in the scrim, and display the categories.
+        &:checked {
             + label {
-                // The scrim that covers the content below
-                // with a dark overlay. It's hidden by default.
+                span {
+                    text-decoration: underline;
+                }
+
+                svg {
+                    transform: rotate(180deg);
+                }
+
+                // Display the scrim when toggled.
                 &::before {
-                    content: "";
-                    display: block;
-                    position: fixed;
-                    top: 0;
-                    left: 0;
-                    width: 100%;
-                    height: 100vh;
-                    opacity: 0;
-                    pointer-events: none;
-                    background-color: rgba(0, 0, 0, 0.5);
-                    z-index: -1;
-                    transition: opacity 0.15s ease-in-out;
+                    opacity: 1;
+                    pointer-events: auto;
                 }
             }
 
-            // Add focus state around label when input is focused.
-            &:focus + label {
-                outline: 1px dotted currentColor;
-            }
-
-            // When toggled, underline the label, rotate the
-            // icon, fade-in the scrim, and display the categories.
-            &:checked {
-                + label {
-                    span {
-                        text-decoration: underline;
-                    }
-
-                    svg {
-                        transform: rotate(180deg);
-                    }
-
-                    // Display the scrim when toggled.
-                    &::before {
-                        opacity: 1;
-                        pointer-events: auto;
-                    }
-                }
-
-                ~ .wp-block-categories {
-                    display: flex;
-                }
+            ~ .wp-block-categories {
+                display: flex;
             }
         }
+    }
 
-        // The "Categories" label itself
-        .local-header__categories-label {
-            display: flex;
-            align-items: center;
-            text-align: right;
-            color: var(--bar-link-color);
-            cursor: pointer;
-            user-select: none;
+    // The "Categories" label itself
+    .local-header__categories-label {
+        display: flex;
+        align-items: center;
+        text-align: right;
+        color: var(--bar-link-color);
+        cursor: pointer;
+        user-select: none;
+        margin: 0;
+        padding: 0 12px;
+        min-height: var(--bar-min-height);
+        position: absolute;
+        top: 0;
+        right: 9px;
+
+        @include break-small {
+            right: var(--wp--custom--alignment--edge-spacing);
+        }
+
+        svg {
+            margin-left: 12px;
+            stroke: currentColor;
+            transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+        }
+
+        &:hover {
+            color: var(--bar-link-hover-color);
+        }
+    }
+
+    // The list of categories which is toggled
+    // on and off using the label+checkbox above.
+    .wp-block-categories {
+        list-style: none;
+        padding: 0 0 30px 0;
+        display: none;
+        flex-direction: column;
+        flex-wrap: wrap;
+
+        // Override the default margin applied to the block.
+        [class*="wp-container-"] & {
             margin: 0;
-            padding: 0 12px;
-            min-height: var(--bar-min-height);
-            position: absolute;
-            top: 0;
-            right: 9px;
+        }
 
-            @include break-small {
-                right: var(--wp--custom--alignment--edge-spacing);
-            }
+        li {
+            padding: 6px 40px 6px 24px;
+            text-align: right;
 
-            svg {
-                margin-left: 12px;
-                stroke: currentColor;
-                transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
-            }
-
-            &:hover {
-                color: var(--bar-link-hover-color);
+            a {
+                display: block;
             }
         }
 
-        // The list of categories which is toggled
-        // on and off using the label+checkbox above.
-        .wp-block-categories {
-            list-style: none;
-            padding: 0 0 30px 0;
-            display: none;
-            flex-direction: column;
-            flex-wrap: wrap;
-
-            // Override the default margin applied to the block.
-            [class*="wp-container-"] & {
-                margin: 0;
-            }
+        @include break-small {
+            flex-direction: row;
 
             li {
-                padding: 6px 40px 6px 24px;
-                text-align: right;
+                width: 100%;
+                padding: 4px 0;
+                text-align: left;
+            }
+        }
 
-                a {
-                    display: block;
-                }
+        @include break-medium {
+            li {
+                width: 50%;
+            }
+        }
+
+        @include break-large {
+            li {
+                width: 25%;
+            }
+        }
+
+        @include break-wide {
+            li {
+                width: 20%;
+            }
+        }
+
+        // If currently viewing a category, highlighted
+        // that category in the list.
+        .current-cat {
+            font-weight: 700;
+            position: relative;
+
+            // On small viewports the current category is highlighted
+            // using a right-side border.
+            &::before {
+                height: auto;
+                width: 4px;
+                content: "";
+                background: var(--bar-text-color);
+                position: absolute;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: auto;
             }
 
             @include break-small {
-                flex-direction: row;
+                // On large viewports the current category is highlighted
+                // using padding an a square.
+                padding-right: 0;
+                padding-left: 16px;
 
-                li {
-                    width: 100%;
-                    padding: 4px 0;
-                    text-align: left;
-                }
-            }
-
-            @include break-medium {
-                li {
-                    width: 50%;
-                }
-            }
-
-            @include break-large {
-                li {
-                    width: 25%;
-                }
-            }
-
-            @include break-wide {
-                li {
-                    width: 20%;
-                }
-            }
-
-            // If currently viewing a category, highlighted
-            // that category in the list.
-            .current-cat {
-                font-weight: 700;
-                position: relative;
-
-                // On small viewports the current category is highlighted
-                // using a right-side border.
                 &::before {
-                    height: auto;
-                    width: 4px;
-                    content: "";
-                    background: var(--bar-text-color);
-                    position: absolute;
-                    top: 0;
-                    right: 0;
-                    bottom: 0;
-                    left: auto;
-                }
-
-                @include break-small {
-                    // On large viewports the current category is highlighted
-                    // using padding an a square.
-                    padding-right: 0;
-                    padding-left: 16px;
-
-                    &::before {
-                        height: 4px;
-                        top: calc(50% - 2px);
-                        right: auto;
-                        left: 0;
-                    }
+                    height: 4px;
+                    top: calc(50% - 2px);
+                    right: auto;
+                    left: 0;
                 }
             }
         }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
@@ -2,175 +2,175 @@
 // over highlighted categories.
 .local-header__categories {
 
-    // The (hidden) checkbox which allows
-    // for toggling the menu on and off.
-    .local-header__categories-toggle {
+	// The (hidden) checkbox which allows
+	// for toggling the menu on and off.
+	.local-header__categories-toggle {
 
-        @include hide-accessibly;
+		@include hide-accessibly;
 
-        + label {
-            // The scrim that covers the content below
-            // with a dark overlay. It's hidden by default.
-            &::before {
-                content: "";
-                display: block;
-                position: fixed;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100vh;
-                opacity: 0;
-                pointer-events: none;
-                background-color: rgba(0, 0, 0, 0.5);
-                z-index: -1;
-                transition: opacity 0.15s ease-in-out;
-            }
-        }
+		+ label {
+			// The scrim that covers the content below
+			// with a dark overlay. It's hidden by default.
+			&::before {
+				content: "";
+				display: block;
+				position: fixed;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100vh;
+				opacity: 0;
+				pointer-events: none;
+				background-color: rgba(0, 0, 0, 0.5);
+				z-index: -1;
+				transition: opacity 0.15s ease-in-out;
+			}
+		}
 
-        // Add focus state around label when input is focused.
-        &:focus + label {
-            outline: 1px dotted currentColor;
-        }
+		// Add focus state around label when input is focused.
+		&:focus + label {
+			outline: 1px dotted currentColor;
+		}
 
-        // When toggled, underline the label, rotate the
-        // icon, fade-in the scrim, and display the categories.
-        &:checked {
-            + label {
-                span {
-                    text-decoration: underline;
-                }
+		// When toggled, underline the label, rotate the
+		// icon, fade-in the scrim, and display the categories.
+		&:checked {
+			+ label {
+				span {
+					text-decoration: underline;
+				}
 
-                svg {
-                    transform: rotate(180deg);
-                }
+				svg {
+					transform: rotate(180deg);
+				}
 
-                // Display the scrim when toggled.
-                &::before {
-                    opacity: 1;
-                    pointer-events: auto;
-                }
-            }
+				// Display the scrim when toggled.
+				&::before {
+					opacity: 1;
+					pointer-events: auto;
+				}
+			}
 
-            ~ .wp-block-categories {
-                display: flex;
-            }
-        }
-    }
+			~ .wp-block-categories {
+				display: flex;
+			}
+		}
+	}
 
-    // The "Categories" label itself
-    .local-header__categories-label {
-        display: flex;
-        align-items: center;
-        text-align: right;
-        color: var(--bar-link-color);
-        cursor: pointer;
-        user-select: none;
-        margin: 0;
-        padding: 0 12px;
-        min-height: var(--bar-min-height);
-        position: absolute;
-        top: 0;
-        right: 9px;
+	// The "Categories" label itself
+	.local-header__categories-label {
+		display: flex;
+		align-items: center;
+		text-align: right;
+		color: var(--bar-link-color);
+		cursor: pointer;
+		user-select: none;
+		margin: 0;
+		padding: 0 12px;
+		min-height: var(--bar-min-height);
+		position: absolute;
+		top: 0;
+		right: 9px;
 
-        @include break-small {
-            right: var(--wp--custom--alignment--edge-spacing);
-        }
+		@include break-small {
+			right: var(--wp--custom--alignment--edge-spacing);
+		}
 
-        svg {
-            margin-left: 12px;
-            stroke: currentColor;
-            transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
-        }
+		svg {
+			margin-left: 12px;
+			stroke: currentColor;
+			transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+		}
 
-        &:hover {
-            color: var(--bar-link-hover-color);
-        }
-    }
+		&:hover {
+			color: var(--bar-link-hover-color);
+		}
+	}
 
-    // The list of categories which is toggled
-    // on and off using the label+checkbox above.
-    .wp-block-categories {
-        list-style: none;
-        padding: 0 0 30px 0;
-        display: none;
-        flex-direction: column;
-        flex-wrap: wrap;
+	// The list of categories which is toggled
+	// on and off using the label+checkbox above.
+	.wp-block-categories {
+		list-style: none;
+		padding: 0 0 30px 0;
+		display: none;
+		flex-direction: column;
+		flex-wrap: wrap;
 
-        // Override the default margin applied to the block.
-        [class*="wp-container-"] & {
-            margin: 0;
-        }
+		// Override the default margin applied to the block.
+		[class*="wp-container-"] & {
+			margin: 0;
+		}
 
-        li {
-            padding: 6px 40px 6px 24px;
-            text-align: right;
+		li {
+			padding: 6px 40px 6px 24px;
+			text-align: right;
 
-            a {
-                display: block;
-            }
-        }
+			a {
+				display: block;
+			}
+		}
 
-        @include break-small {
-            flex-direction: row;
+		@include break-small {
+			flex-direction: row;
 
-            li {
-                width: 100%;
-                padding: 4px 0;
-                text-align: left;
-            }
-        }
+			li {
+				width: 100%;
+				padding: 4px 0;
+				text-align: left;
+			}
+		}
 
-        @include break-medium {
-            li {
-                width: 50%;
-            }
-        }
+		@include break-medium {
+			li {
+				width: 50%;
+			}
+		}
 
-        @include break-large {
-            li {
-                width: 25%;
-            }
-        }
+		@include break-large {
+			li {
+				width: 25%;
+			}
+		}
 
-        @include break-wide {
-            li {
-                width: 20%;
-            }
-        }
+		@include break-wide {
+			li {
+				width: 20%;
+			}
+		}
 
-        // If currently viewing a category, highlighted
-        // that category in the list.
-        .current-cat {
-            font-weight: 700;
-            position: relative;
+		// If currently viewing a category, highlighted
+		// that category in the list.
+		.current-cat {
+			font-weight: 700;
+			position: relative;
 
-            // On small viewports the current category is highlighted
-            // using a right-side border.
-            &::before {
-                height: auto;
-                width: 4px;
-                content: "";
-                background: var(--bar-text-color);
-                position: absolute;
-                top: 0;
-                right: 0;
-                bottom: 0;
-                left: auto;
-            }
+			// On small viewports the current category is highlighted
+			// using a right-side border.
+			&::before {
+				height: auto;
+				width: 4px;
+				content: "";
+				background: var(--bar-text-color);
+				position: absolute;
+				top: 0;
+				right: 0;
+				bottom: 0;
+				left: auto;
+			}
 
-            @include break-small {
-                // On large viewports the current category is highlighted
-                // using padding an a square.
-                padding-right: 0;
-                padding-left: 16px;
+			@include break-small {
+				// On large viewports the current category is highlighted
+				// using padding an a square.
+				padding-right: 0;
+				padding-left: 16px;
 
-                &::before {
-                    height: 4px;
-                    top: calc(50% - 2px);
-                    right: auto;
-                    left: 0;
-                }
-            }
-        }
-    }
+				&::before {
+					height: 4px;
+					top: calc(50% - 2px);
+					right: auto;
+					left: 0;
+				}
+			}
+		}
+	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
@@ -1,178 +1,178 @@
 body .wp-site-blocks .local-header {
-	// The Categories button toggles the display of the list
-	// over highlighted categories.
-	.local-header__categories {
+    // The Categories button toggles the display of the list
+    // over highlighted categories.
+    .local-header__categories {
 
-		// The (hidden) checkbox which allows
-		// for toggling the menu on and off.
-		.local-header__categories-toggle {
+        // The (hidden) checkbox which allows
+        // for toggling the menu on and off.
+        .local-header__categories-toggle {
 
-			@include hide-accessibly;
+            @include hide-accessibly;
 
-			+ label {
-				// The scrim that covers the content below
-				// with a dark overlay. It's hidden by default.
-				&::before {
-					content: "";
-					display: block;
-					position: fixed;
-					top: 0;
-					left: 0;
-					width: 100%;
-					height: 100vh;
-					opacity: 0;
-					pointer-events: none;
-					background-color: rgba(0, 0, 0, 0.5);
-					z-index: -1;
-					transition: opacity 0.15s ease-in-out;
-				}
-			}
+            + label {
+                // The scrim that covers the content below
+                // with a dark overlay. It's hidden by default.
+                &::before {
+                    content: "";
+                    display: block;
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 100vh;
+                    opacity: 0;
+                    pointer-events: none;
+                    background-color: rgba(0, 0, 0, 0.5);
+                    z-index: -1;
+                    transition: opacity 0.15s ease-in-out;
+                }
+            }
 
-			// Add focus state around label when input is focused.
-			&:focus + label {
-				outline: 1px dotted currentColor;
-			}
+            // Add focus state around label when input is focused.
+            &:focus + label {
+                outline: 1px dotted currentColor;
+            }
 
-			// When toggled, underline the label, rotate the
-			// icon, fade-in the scrim, and display the categories.
-			&:checked {
-				+ label {
-					span {
-						text-decoration: underline;
-					}
+            // When toggled, underline the label, rotate the
+            // icon, fade-in the scrim, and display the categories.
+            &:checked {
+                + label {
+                    span {
+                        text-decoration: underline;
+                    }
 
-					svg {
-						transform: rotate(180deg);
-					}
+                    svg {
+                        transform: rotate(180deg);
+                    }
 
-					// Display the scrim when toggled.
-					&::before {
-						opacity: 1;
-						pointer-events: auto;
-					}
-				}
+                    // Display the scrim when toggled.
+                    &::before {
+                        opacity: 1;
+                        pointer-events: auto;
+                    }
+                }
 
-				~ .wp-block-categories {
-					display: flex;
-				}
-			}
-		}
+                ~ .wp-block-categories {
+                    display: flex;
+                }
+            }
+        }
 
-		// The "Categories" label itself
-		.local-header__categories-label {
-			display: flex;
-			align-items: center;
-			text-align: right;
-			color: var(--bar-link-color);
-			cursor: pointer;
-			user-select: none;
-			margin: 0;
-			padding: 0 12px;
-			min-height: var(--bar-min-height);
-			position: absolute;
-			top: 0;
-			right: 9px;
+        // The "Categories" label itself
+        .local-header__categories-label {
+            display: flex;
+            align-items: center;
+            text-align: right;
+            color: var(--bar-link-color);
+            cursor: pointer;
+            user-select: none;
+            margin: 0;
+            padding: 0 12px;
+            min-height: var(--bar-min-height);
+            position: absolute;
+            top: 0;
+            right: 9px;
 
-			@include break-small {
-				right: var(--wp--custom--alignment--edge-spacing);
-			}
+            @include break-small {
+                right: var(--wp--custom--alignment--edge-spacing);
+            }
 
-			svg {
-				margin-left: 12px;
-				stroke: currentColor;
-				transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
-			}
+            svg {
+                margin-left: 12px;
+                stroke: currentColor;
+                transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+            }
 
-			&:hover {
-				color: var(--bar-link-hover-color);
-			}
-		}
+            &:hover {
+                color: var(--bar-link-hover-color);
+            }
+        }
 
-		// The list of categories which is toggled
-		// on and off using the label+checkbox above.
-		.wp-block-categories {
-			list-style: none;
-			padding: 0 0 30px 0;
-			display: none;
-			flex-direction: column;
-			flex-wrap: wrap;
+        // The list of categories which is toggled
+        // on and off using the label+checkbox above.
+        .wp-block-categories {
+            list-style: none;
+            padding: 0 0 30px 0;
+            display: none;
+            flex-direction: column;
+            flex-wrap: wrap;
 
-			// Override the default margin applied to the block.
-			[class*="wp-container-"] & {
-				margin: 0;
-			}
+            // Override the default margin applied to the block.
+            [class*="wp-container-"] & {
+                margin: 0;
+            }
 
-			li {
-				padding: 6px 40px 6px 24px;
-				text-align: right;
+            li {
+                padding: 6px 40px 6px 24px;
+                text-align: right;
 
-				a {
-					display: block;
-				}
-			}
+                a {
+                    display: block;
+                }
+            }
 
-			@include break-small {
-				flex-direction: row;
+            @include break-small {
+                flex-direction: row;
 
-				li {
-					width: 100%;
-					padding: 4px 0;
-					text-align: left;
-				}
-			}
+                li {
+                    width: 100%;
+                    padding: 4px 0;
+                    text-align: left;
+                }
+            }
 
-			@include break-medium {
-				li {
-					width: 50%;
-				}
-			}
+            @include break-medium {
+                li {
+                    width: 50%;
+                }
+            }
 
-			@include break-large {
-				li {
-					width: 25%;
-				}
-			}
+            @include break-large {
+                li {
+                    width: 25%;
+                }
+            }
 
-			@include break-wide {
-				li {
-					width: 20%;
-				}
-			}
+            @include break-wide {
+                li {
+                    width: 20%;
+                }
+            }
 
-			// If currently viewing a category, highlighted
-			// that category in the list.
-			.current-cat {
-				font-weight: 700;
-				position: relative;
+            // If currently viewing a category, highlighted
+            // that category in the list.
+            .current-cat {
+                font-weight: 700;
+                position: relative;
 
-				// On small viewports the current category is highlighted
-				// using a right-side border.
-				&::before {
-					height: auto;
-					width: 4px;
-					content: "";
-					background: var(--bar-text-color);
-					position: absolute;
-					top: 0;
-					right: 0;
-					bottom: 0;
-					left: auto;
-				}
+                // On small viewports the current category is highlighted
+                // using a right-side border.
+                &::before {
+                    height: auto;
+                    width: 4px;
+                    content: "";
+                    background: var(--bar-text-color);
+                    position: absolute;
+                    top: 0;
+                    right: 0;
+                    bottom: 0;
+                    left: auto;
+                }
 
-				@include break-small {
-					// On large viewports the current category is highlighted
-					// using padding an a square.
-					padding-right: 0;
-					padding-left: 16px;
+                @include break-small {
+                    // On large viewports the current category is highlighted
+                    // using padding an a square.
+                    padding-right: 0;
+                    padding-left: 16px;
 
-					&::before {
-						height: 4px;
-						top: calc(50% - 2px);
-						right: auto;
-						left: 0;
-					}
-				}
-			}
-		}
-	}
+                    &::before {
+                        height: 4px;
+                        top: calc(50% - 2px);
+                        right: auto;
+                        left: 0;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
@@ -1,76 +1,4 @@
 body .wp-site-blocks .local-header {
-	--bar-min-height: 58px;
-	--bar-text-color: var(--wp--preset--color--white);
-	--bar-link-color: var(--wp--preset--color--white);
-	--bar-link-hover-color: var(--wp--preset--color--off-white-2);
-	--bar-background-color: var(--wp--preset--color--blue-1);
-
-	color: var(--bar-text-color);
-	min-height: var(--bar-min-height);
-	position: relative;
-	background: linear-gradient(to top, transparent var(--bar-min-height), var(--bar-background-color) var(--bar-min-height) 100%);
-
-	&::after {
-		content: "";
-		min-height: var(--bar-min-height);
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		z-index: -1;
-		mask-image: url(images/local-nav-mask.svg);
-		mask-repeat: no-repeat;
-		mask-size: cover;
-		mask-position: 0;
-		background-color: var(--bar-background-color);
-	}
-
-	// A container with a paint stroke effect that holds both
-	// the breadcrumbs and category dropdown.
-	.local-header__navigation {
-		// Allows for absolute positioning for the Categories
-		// toggle button.
-		position: relative;
-
-		padding: 0 0 0 24px;
-
-		@include break-small {
-			padding: 0 var(--wp--custom--alignment--edge-spacing);
-		}
-	}
-
-	// Breadcrumbs show the lineage of pages based on the current
-	// page. It contains a link for each parent.
-	.local-header__breadcrumb {
-		display: flex;
-		align-items: center;
-		min-height: var(--bar-min-height);
-		color: var(--bar-text-color);
-
-		// The current item is highlighted.
-		&-current {
-			font-family: var(--wp--preset--font-family--inter);
-			font-size: 1rem;
-			font-weight: 700;
-
-			// This ensures that the square separator
-			// is reliably centered.
-			display: flex;
-			align-items: center;
-			margin-top: 0;
-
-			&::before {
-				content: "";
-				height: 2px;
-				width: 2px;
-				background: var(--bar-text-color);
-				display: inline-block;
-				margin: 0 0.5rem;
-				border-radius: 2px;
-			}
-		}
-	}
-
 	// The Categories button toggles the display of the list
 	// over highlighted categories.
 	.local-header__categories {
@@ -245,15 +173,6 @@ body .wp-site-blocks .local-header {
 					}
 				}
 			}
-		}
-	}
-
-	a {
-		color: var(--bar-link-color);
-
-		&:hover {
-			color: var(--bar-link-hover-color);
-			text-decoration: underline;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
@@ -1,4 +1,4 @@
-body .wp-site-blocks .local-header {
+.local-header {
 	--bar-min-height: 58px;
 	--bar-text-color: var(--wp--preset--color--white);
 	--bar-link-color: var(--wp--preset--color--white);

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
@@ -1,0 +1,50 @@
+body .wp-site-blocks .local-header {
+	--bar-min-height: 58px;
+	--bar-text-color: var(--wp--preset--color--white);
+	--bar-link-color: var(--wp--preset--color--white);
+	--bar-link-hover-color: var(--wp--preset--color--off-white-2);
+	--bar-background-color: var(--wp--preset--color--blue-1);
+
+	color: var(--bar-text-color);
+	min-height: var(--bar-min-height);
+	position: relative;
+	background: linear-gradient(to top, transparent var(--bar-min-height), var(--bar-background-color) var(--bar-min-height) 100%);
+
+	&::after {
+		content: "";
+		min-height: var(--bar-min-height);
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		z-index: -1;
+		mask-image: url(images/local-nav-mask.svg);
+		mask-repeat: no-repeat;
+		mask-size: cover;
+		mask-position: 0;
+		background-color: var(--bar-background-color);
+	}
+
+	// A container with a paint stroke effect that holds both
+	// the breadcrumbs and category dropdown.
+	.local-header__navigation {
+		// Allows for absolute positioning for the Categories
+		// toggle button.
+		position: relative;
+
+		padding: 0 0 0 24px;
+
+		@include break-small {
+			padding: 0 var(--wp--custom--alignment--edge-spacing);
+		}
+	}
+
+	a {
+		color: var(--bar-link-color);
+
+		&:hover {
+			color: var(--bar-link-hover-color);
+			text-decoration: underline;
+		}
+	}
+}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
@@ -14,7 +14,7 @@
 		content: "";
 		min-height: var(--bar-min-height);
 		position: absolute;
-		bottom: 0;
+		bottom: 1px;
 		left: 0;
 		right: 0;
 		z-index: -1;

--- a/source/wp-content/themes/wporg-news-2021/sass/style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/style.scss
@@ -59,7 +59,9 @@ GNU General Public License for more details.
 // These style generic/custom components like the site header, footer archive, local navigation, etc.
 // Global components are listed first, to apply default styles.
 @import "components/site-header";
-@import "components/local-header";
+@import "components/local-header/local-header";
+@import "components/local-header/breadcrumbs";
+@import "components/local-header/categories";
 @import "components/bottom-banner/bottom-banner";
 @import "components/bottom-banner/subscribe-wp-news";
 @import "components/bottom-banner/wp-briefing";


### PR DESCRIPTION
This is a small PR that breaks down the CSS in `components/_local-header.scss` into multiple, smaller .scss files.

I went with creating a new directory called `local-header`, and then breaking down the contents into `local-header`, `breadcrumbs` and `categories`.

Closes #52.