### PR TITLE
Captions: Adjust side margins, remove boilerplate from Blockbase

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
@@ -29,12 +29,10 @@ a {
 	figcaption {
 		font-size: var(--wp--custom--gallery--caption--font-size);
 		text-align: right;
-		padding-left: var(--wp--style--block-gap);
-		padding-right: var(--wp--style--block-gap);
 	}
 
 	&.alignfull {
-		figcaption {
+		> figcaption {
 			padding-right: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--style--block-gap));
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
@@ -25,10 +25,19 @@ a {
 
 // Captions
 .wp-block-gallery.wp-block-gallery, // Double class for increased specificity.
+figure[class*="wp-block-"],
 [class*="wp-block-"] {
 	figcaption {
 		font-size: var(--wp--custom--gallery--caption--font-size);
 		text-align: right;
+		margin-top: 1em;
+		margin-bottom: 1em;
+	}
+
+	&.wp-block-gallery.has-nested-images {
+		> figcaption {
+			margin-top: 0;
+		}
 	}
 
 	&.alignfull {

--- a/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
@@ -33,7 +33,7 @@ a {
 
 	&.alignfull {
 		> figcaption {
-			padding-right: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--style--block-gap));
+			padding-right: var(--wp--style--block-gap);
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_video.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_video.scss
@@ -1,6 +1,0 @@
-.wp-block-video {
-	figcaption {
-		margin: var(--wp--custom--video--caption--margin);
-		text-align: var(--wp--custom--video--caption--text-align);
-	}
-}

--- a/source/wp-content/themes/wporg-news-2021/sass/style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/style.scss
@@ -51,7 +51,6 @@ GNU General Public License for more details.
 @import "blocks/social-links";
 @import "blocks/file";
 @import "blocks/table";
-@import "blocks/video";
 @import "blocks/columns";
 
 

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -392,12 +392,6 @@
 						"fontSize": "var(--wp--preset--font-size--tiny)"
 					}
 				}
-			},
-			"video": {
-				"caption": {
-					"textAlign": "center",
-					"margin": "var(--wp--custom--margin--vertical) auto"
-				}
 			}
 		},
 		"layout": {


### PR DESCRIPTION
* Removes side margins from figcaption elements, since the figure
  container will already have some whitespace around it.
* Except when the figure container is set to full-width, in which case
  some margin is applied to the right side.
* Removes custom styles for the video block that came over from
  Blockbase, but do not appear to be intended for the News site design.

Relates to #274

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/916023/152063758-cdaa6562-717a-4212-941f-12700a0a746a.jpg) | ![after](https://user-images.githubusercontent.com/916023/152063773-5ba80b82-f7be-4db4-bee5-9de08389c623.jpg) |

| Full width |
| --- |
| ![full-width](https://user-images.githubusercontent.com/916023/152064592-9e7ffe65-6789-4641-936e-35390cc7d249.jpg) |

