### PR TITLE
Add template part for category archive content that omits category list

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category.html
@@ -1,0 +1,17 @@
+<!-- wp:group {"tagName":"header","className":"entry-header"} -->
+<header class="wp-block-group entry-header">
+	<!-- wp:post-title {"level":2,"isLink":true} /-->
+
+	<!-- wp:group {"className":"entry-meta"} -->
+	<div class="wp-block-group entry-meta">
+		<!-- wp:post-date /-->
+	</div>
+	<!-- /wp:group -->
+</header>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section"} -->
+<section class="wp-block-group">
+	<!-- wp:post-excerpt {"moreText":"Read Post","showMoreOnNewLine":true,"layout":{"inherit":true}} /-->
+</section>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category.html
@@ -10,7 +10,7 @@
 	<!-- /wp:group -->
 
 	<!-- wp:post-template -->
-		<!-- wp:template-part {"slug":"content-posts-index","tagName":"article","layout":{"inherit":true}} /-->
+		<!-- wp:template-part {"slug":"content-category","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->


### PR DESCRIPTION
This is another issue that would probably benefit from Gutenberg supporting [dynamic template parts](https://github.com/WordPress/gutenberg/issues/32939). Since it doesn't, the workaround here is to add a `content-category.html` template part file so that category archives that don't have their own specific templates don't show the list of assigned categories on every post, since that would be redundant.

Fixes #273