### PR TITLE
Sort category menu by column instead of row

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/local-navigation.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/local-navigation.html
@@ -26,7 +26,7 @@
 			</svg>
 		</label>
 		<!-- /wp:html -->
-		<!-- wp:categories /-->
+		<!-- wp:categories {"showOnlyTopLevel":true} /-->
 	</div>
 	<!-- /wp:group -->
 </div>

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
@@ -54,7 +54,7 @@
 			}
 
 			~ .wp-block-categories {
-				display: flex;
+				display: block;
 			}
 		}
 	}
@@ -95,8 +95,6 @@
 		list-style: none;
 		padding: 0 0 30px 0;
 		display: none;
-		flex-direction: column;
-		flex-wrap: wrap;
 		max-height: none;
 
 		// Override the default margin applied to the block.
@@ -114,32 +112,24 @@
 		}
 
 		@include break-small {
-			flex-direction: column;
-			max-height: 200px;
+			column-count: 2;
 
 			li {
-				width: 100%;
 				padding: 4px 0;
 				text-align: left;
 			}
 		}
 
 		@include break-medium {
-			li {
-				width: 50%;
-			}
+			column-count: 3;
 		}
 
 		@include break-large {
-			li {
-				width: 25%;
-			}
+			column-count: 4;
 		}
 
 		@include break-wide {
-			li {
-				width: 20%;
-			}
+			column-count: 5;
 		}
 
 		// If currently viewing a category, highlighted

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
@@ -97,6 +97,7 @@
 		display: none;
 		flex-direction: column;
 		flex-wrap: wrap;
+		max-height: 200px;
 
 		// Override the default margin applied to the block.
 		[class*="wp-container-"] & {
@@ -113,7 +114,7 @@
 		}
 
 		@include break-small {
-			flex-direction: row;
+			//flex-direction: row;
 
 			li {
 				width: 100%;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
@@ -97,7 +97,7 @@
 		display: none;
 		flex-direction: column;
 		flex-wrap: wrap;
-		max-height: 200px;
+		max-height: none;
 
 		// Override the default margin applied to the block.
 		[class*="wp-container-"] & {
@@ -114,7 +114,8 @@
 		}
 
 		@include break-small {
-			//flex-direction: row;
+			flex-direction: column;
+			max-height: 200px;
 
 			li {
 				width: 100%;


### PR DESCRIPTION
Fresh attempt to fix #146, replaces #243.

I can't figure out why the `flex-direction` in `break-small` seems to override the `column` sort. This breaks the vertical menu at small sizes, but has the correct sorting on wider screens.
