### PR TITLE
Fix title spacing on category archive.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -345,9 +345,9 @@ body {
 	}
 
 	&.category .wp-block-post {
-		margin-bottom: 20px;
+		padding-bottom: 20px;
 		@include break-mobile() {
-			margin-bottom: 60px;
+			margin-bottom: 40px;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -345,6 +345,9 @@ body {
 	}
 
 	&.category .wp-block-post {
-		margin-bottom: 60px;
+		margin-bottom: 20px;
+		@include break-mobile() {
+			margin-bottom: 60px;
+		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -343,4 +343,8 @@ body {
 			}
 		}
 	}
+
+	&.category .wp-block-post {
+		margin-bottom: 60px;
+	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
@@ -21,6 +21,12 @@
 		}
 	}
 
+	.archive & {
+		.wp-block-post-title {
+			margin-bottom: 10px;
+		}
+	}
+
 	.single &,
 	.page & {
 		margin-top: 8px;


### PR DESCRIPTION
Fixes #263.

Before:
<img width="742" alt="Screen Shot 2022-02-02 at 5 51 25 pm" src="https://user-images.githubusercontent.com/7200686/152107273-d96e8df6-01bb-4611-be9b-d594f3c4d1ee.png">

After:
<img width="730" alt="Screen Shot 2022-02-02 at 5 50 58 pm" src="https://user-images.githubusercontent.com/7200686/152107289-fda11128-82d4-4f1e-b6fb-0f37b80f1468.png">

