### PR TITLE
Reduce query title banner spacing

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
@@ -38,8 +38,11 @@ body.archive .query-title-banner__query-title,
 body.news-posts-index .query-title-banner__all-posts,
 body.search .query-title-banner__search-results {
 	display: block;
-	margin-top: 0;
 	margin-bottom: 0;
+
+	@include break-mobile() {
+		margin-top: 0;
+	}
 }
 
 // Setup the basic two-column layout;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
@@ -38,6 +38,8 @@ body.archive .query-title-banner__query-title,
 body.news-posts-index .query-title-banner__all-posts,
 body.search .query-title-banner__search-results {
 	display: block;
+	margin-top: 0;
+	margin-bottom: 0;
 }
 
 // Setup the basic two-column layout;


### PR DESCRIPTION
Quick first stab.

Before:
<img width="1019" alt="Screen Shot 2022-02-02 at 6 39 21 pm" src="https://user-images.githubusercontent.com/7200686/152112848-eaf55b27-5b22-4a85-af34-bebcd417d64f.png">


After:
<img width="1029" alt="Screen Shot 2022-02-02 at 6 38 04 pm" src="https://user-images.githubusercontent.com/7200686/152112748-21e08b24-00ab-4b7e-aa87-ed99995fc256.png">

How big should the banner be?