### PR TITLE
Remove unused custom css var definitions from theme.json and stylesheets

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
@@ -63,12 +63,10 @@ textarea {
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 	border-radius: var(--wp--custom--form--border--radius);
 	box-shadow: var(--wp--custom--form--color--box-shadow);
-	color: var(--wp--custom--form--color--text);
 	font-family: inherit;
 	padding: var(--wp--custom--form--padding);
 
 	&:focus {
-		color: var(--wp--custom--form--color--text);
 		border-color: var(--custom--form--color--border);
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_html.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_html.scss
@@ -1,6 +1,5 @@
 .block-library-html__edit {
 	.block-editor-plain-text {
-		color: var(--wp--custom--form--color--text);
 		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_latest-posts.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_latest-posts.scss
@@ -1,4 +1,0 @@
-.wp-block-latest-posts .wp-block-latest-posts__post-date,
-.wp-block-latest-posts .wp-block-latest-posts__post-author {
-	color: var(--wp--custom--latest-posts--meta--color--text);
-}

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_paragraph.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_paragraph.scss
@@ -1,9 +1,4 @@
 p {
-	// Override `color: inherit` from Core styles.
-	&.has-text-color a {
-		color: var(--wp--style--color--link, var(--wp--custom--color--primary));
-	}
-
 	&.has-drop-cap:not(:focus)::first-letter {
 		font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
 		font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-comments.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-comments.scss
@@ -36,7 +36,6 @@
 
 		input:not([type="submit"]):not([type="checkbox"]),
 		textarea {
-			background: var(--wp--custom--color--background);
 			border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 			width: 100%;
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/style.scss
@@ -36,7 +36,6 @@ GNU General Public License for more details.
 @import "blocks/button";
 @import "blocks/html";
 @import "blocks/image";
-@import "blocks/latest-posts";
 @import "blocks/list";
 @import "blocks/paragraph";
 @import "blocks/post-author";

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -203,9 +203,6 @@
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--tiny)"
 					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
 			"gallery": {

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -103,8 +103,7 @@
 			"alignment": {
 				"alignedMaxWidth": "50%",
 				"//edge-spacing": "The min and max values represent the mobile and desktop spacing; the calc() value is for tablets.",
-				"edge-spacing": "clamp( 24px, calc( 100vw / 18 ), 80px )",
-				"scroll-bar-width": "8px"
+				"edge-spacing": "clamp( 24px, calc( 100vw / 18 ), 80px )"
 			},
 			"button": {
 				"color": {

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -163,13 +163,6 @@
 					"fontFamily": "monospace"
 				}
 			},
-			"color": {
-				"foreground": "var(--wp--preset--color--foreground)",
-				"background": "var(--wp--preset--color--background)",
-				"primary": "var(--wp--preset--color--primary)",
-				"secondary": "var(--wp--preset--color--secondary)",
-				"selection": "var(--wp--preset--color--selection)"
-			},
 			"form": {
 				"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
 				"border": {
@@ -205,8 +198,7 @@
 				},
 				"color": {
 					"background": "transparent",
-					"boxShadow": "none",
-					"text": "var(--wp--custom--color--foreground)"
+					"boxShadow": "none"
 				},
 				"label": {
 					"typography": {
@@ -306,13 +298,6 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
-				}
-			},
-			"latest-posts": {
-				"meta": {
-					"color": {
-						"text": "var(--wp--custom--color--primary)"
-					}
 				}
 			},
 			"layout": {
@@ -499,10 +484,6 @@
 				}
 			},
 			"core/post-date": {
-				"color": {
-					"link": "var(--wp--custom--color--foreground)",
-					"text": "var(--wp--custom--color--foreground)"
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
@@ -529,9 +510,6 @@
 				}
 			},
 			"core/separator": {
-				"color": {
-					"text": "var(--wp--custom--color--foreground)"
-				},
 				"border": {
 					"color": "currentColor",
 					"style": "solid",


### PR DESCRIPTION
There were a few properties in the `custom` section of the theme.json file that either weren't being used or were pointing to other css variables that didn't exist. These were mostly color variable names that came over from Blockbase. This is just an effort to reduce clutter.

There should not be any visual changes on the site from these deletions.