### PR TITLE
Fix spacing on non-category archives

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
@@ -28,6 +28,10 @@
 				margin: 0 0.5rem;
 				border-radius: 2px;
 			}
+
+			span {
+				margin-left: 0.5ch;
+			}
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -315,11 +315,6 @@ body.category-community {
 body {
 	--category-color: var(--wp--preset--color--blue-1);
 
-	&.category .site-content-container {
-		padding-left: var(--wp--custom--alignment--edge-spacing);
-		padding-right: var(--wp--custom--alignment--edge-spacing);
-	}
-
 	.query-title-banner__title__dropcap {
 		grid-column: 1 !important;
 		width: calc(var(--wp--custom--layout--content-meta-size) - 32px) !important;

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -26,6 +26,7 @@
 body.archive .site-content-container {
 	padding-left: var(--wp--custom--alignment--edge-spacing);
 	padding-right: var(--wp--custom--alignment--edge-spacing);
+	padding-bottom: var(--wp--custom--alignment--edge-spacing);
 }
 
 body.news-posts-index .site-content-container,

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -23,6 +23,11 @@
 	}
 }
 
+body.archive .site-content-container {
+	padding-left: var(--wp--custom--alignment--edge-spacing);
+	padding-right: var(--wp--custom--alignment--edge-spacing);
+}
+
 body.news-posts-index .site-content-container,
 body.archive .site-content-container,
 body.search .site-content-container,


### PR DESCRIPTION
This fixes two issues on non-category archives (dates, tags, etc)

- On screens smaller than 1280px, there was no space around the content
- In the local nav breadcrumbs, the archive title had no space between the label & title

| Type | Before | After |
|------|--------|-------|
| Category (no change) | ![before-cat](https://user-images.githubusercontent.com/541093/152610372-392f98ed-65cc-4b52-8320-b461e5d585c3.png) | ![after-cat](https://user-images.githubusercontent.com/541093/152610367-c910f8d8-b4fb-47db-a707-256187cc9309.png) |
| Date | ![before-date](https://user-images.githubusercontent.com/541093/152610373-e958a8ff-c039-44e9-920b-ba17d8ebffd3.png) | ![after-date](https://user-images.githubusercontent.com/541093/152610370-b362a1d3-c84a-4eab-b7e6-df08a77527f7.png) |
| Tag | ![before-tag](https://user-images.githubusercontent.com/541093/152610374-bc96e7ac-0937-4f1a-9d00-a0058b19f843.png) | ![after-tag](https://user-images.githubusercontent.com/541093/152610371-25a15e89-4e63-4eb4-8bcf-89017b272181.png) |
