### PR TITLE
Add spacing to heading elements and sections of homepage

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -2,7 +2,7 @@
 <!-- wp:query {"query":{"perPage":5},"tagName":"section","className":"front__latest-posts","align":"full"} -->
 <section class="front__latest-posts alignfull">
 	<!-- wp:heading {"level":2,"className":"front__latest-posts-heading front__section-heading"} -->
-	<h2 class="front__latest-posts-heading front__section-heading">Latest Posts</h2>
+	<h2 class="front__latest-posts-heading">Latest Posts</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:post-template -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -1,8 +1,8 @@
 <!-- `perPage` must match the value in `offset_paged_posts()`. -->
 <!-- wp:query {"query":{"perPage":5},"tagName":"section","className":"front__latest-posts","align":"full"} -->
 <section class="front__latest-posts alignfull">
-	<!-- wp:heading {"level":2,"className":"front__latest-posts-heading"} -->
-	<h2 class="front__latest-posts-heading">Latest Posts</h2>
+	<!-- wp:heading {"level":2,"className":"front__latest-posts-heading front__section-heading"} -->
+	<h2 class="front__latest-posts-heading front__section-heading">Latest Posts</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:post-template -->
@@ -20,7 +20,7 @@
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 
-	
+
 	<!-- wp:paragraph {"className":"front__next-page"} -->
 	<p class="front__next-page">
 		<a href="page/2">See All Posts</a>

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-posts.html
@@ -1,7 +1,7 @@
 <!-- `perPage` must match the value in `offset_paged_posts()`. -->
 <!-- wp:query {"query":{"perPage":5},"tagName":"section","className":"front__latest-posts","align":"full"} -->
 <section class="front__latest-posts alignfull">
-	<!-- wp:heading {"level":2,"className":"front__latest-posts-heading front__section-heading"} -->
+	<!-- wp:heading {"level":2,"className":"front__latest-posts-heading"} -->
 	<h2 class="front__latest-posts-heading">Latest Posts</h2>
 	<!-- /wp:heading -->
 

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
@@ -1,6 +1,6 @@
 <!-- wp:query {"query":{"perPage":1,"category":"releases"},"tagName":"section","className":"front__latest-release","align":"full"} -->
 <section class="front__latest-release alignfull">
-	<!-- wp:heading {"level":2,"className":"front__latest-release-heading front__section-heading"} -->
+	<!-- wp:heading {"level":2,"className":"front__latest-release-heading"} -->
 	<h2 class="front__latest-release-heading">Latest Release</h2>
 	<!-- /wp:heading -->
 

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
@@ -1,7 +1,7 @@
 <!-- wp:query {"query":{"perPage":1,"category":"releases"},"tagName":"section","className":"front__latest-release","align":"full"} -->
 <section class="front__latest-release alignfull">
 	<!-- wp:heading {"level":2,"className":"front__latest-release-heading front__section-heading"} -->
-	<h2 class="front__latest-release-heading front__section-heading">Latest Release</h2>
+	<h2 class="front__latest-release-heading">Latest Release</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:post-template -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
@@ -1,7 +1,7 @@
 <!-- wp:query {"query":{"perPage":1,"category":"releases"},"tagName":"section","className":"front__latest-release","align":"full"} -->
 <section class="front__latest-release alignfull">
-	<!-- wp:heading {"level":2,"className":"front__latest-release-heading"} -->
-	<h2 class="front__latest-release-heading">Latest Release</h2>
+	<!-- wp:heading {"level":2,"className":"front__latest-release-heading front__section-heading"} -->
+	<h2 class="front__latest-release-heading front__section-heading">Latest Release</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:post-template -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -1,7 +1,7 @@
 <!-- wp:query {"query":{"perPage":5,"postType":"post","tag":"people-of-wordpress"},"tagName":"section","className":"front__people-of-wordpress","align":"full"} -->
 <section class="front__people-of-wordpress alignfull">
-	<!-- wp:heading {"level":2} -->
-	<h2>People of WordPress</h2>
+	<!-- wp:heading {"level":2,"className":"front__people-of-wordpress-heading front__section-heading"} -->
+	<h2 class="front__people-of-wordpress-heading front__section-heading">People of WordPress</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:post-template {"align":"full"} -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -1,7 +1,7 @@
 <!-- wp:query {"query":{"perPage":5,"postType":"post","tag":"people-of-wordpress"},"tagName":"section","className":"front__people-of-wordpress","align":"full"} -->
 <section class="front__people-of-wordpress alignfull">
 	<!-- wp:heading {"level":2,"className":"front__people-of-wordpress-heading front__section-heading"} -->
-	<h2 class="front__people-of-wordpress-heading front__section-heading">People of WordPress</h2>
+	<h2 class="front__people-of-wordpress-heading">People of WordPress</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:post-template {"align":"full"} -->

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -1,6 +1,6 @@
 <!-- wp:query {"query":{"perPage":5,"postType":"post","tag":"people-of-wordpress"},"tagName":"section","className":"front__people-of-wordpress","align":"full"} -->
 <section class="front__people-of-wordpress alignfull">
-	<!-- wp:heading {"level":2,"className":"front__people-of-wordpress-heading front__section-heading"} -->
+	<!-- wp:heading {"level":2,"className":"front__people-of-wordpress-heading"} -->
 	<h2 class="front__people-of-wordpress-heading">People of WordPress</h2>
 	<!-- /wp:heading -->
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_bottom-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_bottom-banner.scss
@@ -23,7 +23,7 @@
 
 	> .wp-block-group {
 		text-align: left;
-		padding: var(--wp--custom--alignment--edge-spacing);
+		padding: calc(var(--wp--custom--alignment--edge-spacing) * 2) var(--wp--custom--alignment--edge-spacing);
 		border-top: 1px solid var(--wp--preset--color--light-grey);
 		width: 100%;
 

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
@@ -16,6 +16,7 @@ body.news-front-page {
 		z-index: 1;
 		background-color: var(--wp--preset--color--blue-1);
 		color: var(--wp--preset--color--white);
+		margin: var(--wp--custom--alignment--edge-spacing) 0 calc(var(--wp--custom--alignment--edge-spacing) * 2);
 		padding: var(--wp--custom--alignment--edge-spacing);
 		font-size: clamp(80px, 25vw, 160px);
 

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
@@ -12,6 +12,7 @@ body.news-front-page .front__latest-posts {
 		font-size: clamp(20px, calc(100vw / 24), 45px);
 		line-height: 1;
 		margin-bottom: var(--wp--custom--alignment--edge-spacing);
+		padding: var(--wp--custom--alignment--edge-spacing) 0;
 		width: calc(var(--wp--custom--layout--content-meta-size) - 32px);
 
 		@include break-medium() {
@@ -55,11 +56,13 @@ body.news-front-page .front__latest-posts {
 
 	.front__next-page {
 		font-size: var(--wp--preset--font-size--small);
+		padding: 0 0 var(--wp--custom--alignment--edge-spacing) 0;
 
 		@include break-medium() {
 			position: absolute;
 			bottom: var(--wp--custom--alignment--edge-spacing);
 			left: var(--wp--custom--alignment--edge-spacing);
+			padding: 0;
 
 			&::before {
 				content: "";

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -33,6 +33,7 @@ body.news-front-page .front__latest-release {
 	.front__latest-release-heading {
 		font-size: clamp(20px, calc(100vw / 24), 45px);
 		line-height: 1;
+		padding: var(--wp--custom--alignment--edge-spacing) 0;
 		width: calc(var(--wp--custom--layout--content-meta-size) - 32px);
 
 		@include break-medium() {
@@ -132,12 +133,14 @@ body.news-front-page .front__latest-release {
 	.front__next-page {
 		position: relative;
 		font-size: var(--wp--preset--font-size--small);
+		padding: var(--wp--custom--alignment--edge-spacing) 0;
 
 		@include break-medium() {
 			line-height: 1;
 			position: absolute;
 			bottom: var(--wp--custom--alignment--edge-spacing);
 			left: var(--wp--custom--alignment--edge-spacing);
+			padding: 0;
 		}
 
 		&::before {

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -70,6 +70,11 @@ body.news-front-page .front__latest-release {
 		@include break-medium() {
 			flex-grow: 1;
 			font-size: 90px;
+			padding:
+				calc(var(--wp--custom--alignment--edge-spacing) / 2)
+				var(--wp--custom--alignment--edge-spacing)
+				var(--wp--custom--alignment--edge-spacing)
+				var(--wp--custom--alignment--edge-spacing);
 
 			a {
 				display: flex;
@@ -77,11 +82,7 @@ body.news-front-page .front__latest-release {
 				align-items: center;
 				z-index: 1;
 				height: 100%;
-				padding:
-					calc(var(--wp--custom--alignment--edge-spacing) / 2)
-					var(--wp--custom--alignment--edge-spacing)
-					var(--wp--custom--alignment--edge-spacing)
-					var(--wp--custom--alignment--edge-spacing);
+				padding: 30px 0;
 				transition: background-color 0.15s linear;
 
 				&::after {

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -76,6 +76,14 @@ body.news-front-page .front__latest-release {
 				var(--wp--custom--alignment--edge-spacing)
 				var(--wp--custom--alignment--edge-spacing);
 
+			&:hover {
+				background-color: rgba(0, 0, 0, 0.1);
+
+				&::after {
+					transform: scale(0.9) translateX(10px);
+				}
+			}
+
 			a {
 				display: flex;
 				flex-direction: row;
@@ -98,14 +106,6 @@ body.news-front-page .front__latest-release {
 					background-repeat: no-repeat;
 					pointer-events: none;
 					transition: all 0.15s linear;
-				}
-
-				&:hover {
-					background-color: rgba(0, 0, 0, 0.1);
-
-					&::after {
-						transform: scale(0.9) translateX(10px);
-					}
 				}
 			}
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -81,7 +81,7 @@ body.news-front-page .front__latest-release {
 			&:focus-within {
 				background-color: rgba(0, 0, 0, 0.1);
 
-				&::after {
+				a::after {
 					transform: scale(0.9) translateX(10px);
 				}
 			}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -77,7 +77,8 @@ body.news-front-page .front__latest-release {
 				var(--wp--custom--alignment--edge-spacing)
 				var(--wp--custom--alignment--edge-spacing);
 
-			&:hover {
+			&:hover,
+			&:focus-within {
 				background-color: rgba(0, 0, 0, 0.1);
 
 				&::after {

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -2,9 +2,13 @@ body.news-front-page .front__people-of-wordpress {
 	background-color: var(--wp--preset--color--off-white);
 	position: relative;
 
-	h2 {
+	.front__people-of-wordpress-heading {
 		font-size: clamp(20px, calc(100vw / 24), 45px);
-		padding: var(--wp--custom--alignment--edge-spacing);
+		padding: calc(var(--wp--custom--alignment--edge-spacing) * 2 ) var(--wp--custom--alignment--edge-spacing);
+
+		@include break-medium() {
+			padding: var(--wp--custom--alignment--edge-spacing);
+		}
 	}
 
 	.wp-block-post-template {
@@ -89,7 +93,10 @@ body.news-front-page .front__people-of-wordpress {
 
 	.front__next-page {
 		font-size: var(--wp--preset--font-size--small);
-		padding: var(--wp--custom--alignment--edge-spacing);
+		padding:
+			var(--wp--custom--alignment--edge-spacing)
+			var(--wp--custom--alignment--edge-spacing)
+			calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--style--block-gap));
 		width: 192px;
 
 		@include break-medium() {


### PR DESCRIPTION
Adds spacing to a few places on the homepage to better match the design, specifically in the mobile view. Also fixes a spacing issue in the latest release section in desktop view when the post title wraps to a second line, which was causing the post date to be too close. See #271 for comparison screenshots.

Fixes #271 