### PR TITLE
Header: Adjust site header to fixed global header CSS

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
@@ -1,13 +1,23 @@
-// The container for the site-specific (/news/) menu bar.
-.site-header-container {
+html {
 
 	@include break-small {
-		position: sticky;
-		top: 0;
-		z-index: 10;
+		scroll-padding-top: calc(var(--wp-global-header-offset, 0px) + 58px);
+		margin-top: calc(var(--wp-global-header-offset, 0px) + 58px);
+	}
+}
+
+// The container for the site-specific (/news/) menu bar.
+.site-header-container {
+	.wp-block-group.global-header {
+		// Unstick the header, since we're sticking the whole container.
+		position: revert;
 	}
 
-	body.admin-bar & {
-		padding-top: var(--wp-admin--admin-bar--height, 0);
+	@include break-small {
+		position: fixed;
+		top: var(--wp-admin--admin-bar--height, 0);
+		left: 0;
+		right: 0;
+		z-index: 10;
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
@@ -1,6 +1,7 @@
 html[lang] {
 
 	@include break-small {
+		// 58px = height of the local nav.
 		scroll-padding-top: calc(var(--wp-global-header-offset, 0px) + 58px);
 		margin-top: calc(var(--wp-global-header-offset, 0px) + 58px);
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
@@ -1,4 +1,4 @@
-html {
+html[lang] {
 
 	@include break-small {
 		scroll-padding-top: calc(var(--wp-global-header-offset, 0px) + 58px);


### PR DESCRIPTION
See https://github.com/WordPress/wporg-mu-plugins/pull/152 — In that PR, we switch the global header to use `fixed` positioning, which breaks how the local nav works here in News. This PR updates the theme CSS to handle that, by unsetting the header-specific positioning, and setting the whole header-container element to fixed positioning. This also uses a custom property `--wp-global-header-offset`, which is set in the global header CSS, to the size of the header + admin bar (if visible).

**To test**

- Try a few different pages, with & without admin bars
- Try at different browser sizes — at `600px` the header stops being sticky, so try at least one size above & one below
- The header should stay stuck to the top of the page
- When scrolled to the top of the page, all content should be visible, no content hidden by the header
- Try using some relative links (for example, `http://localhost:8888/2021/07/configuring-theme-design-with-theme-json/#what-s-theme-json`), the header should not overlap the link target