### PR TITLE
Apply content spacing to all posts as well as categories, except category-community

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -338,12 +338,4 @@ body {
 			}
 		}
 	}
-
-	&.category .wp-block-post {
-		padding-bottom: 20px;
-
-		@include break-mobile() {
-			margin-bottom: 40px;
-		}
-	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -1,3 +1,14 @@
+.wp-block-post {
+	.blog &,
+	.category:not(.category-community) & {
+		padding-bottom: 20px;
+
+		@include break-mobile() {
+			margin-bottom: 40px;
+		}
+	}
+}
+
 .wp-block-post-content {
 	padding-bottom: var(--wp--style--block-gap);
 

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
@@ -21,6 +21,7 @@
 		}
 	}
 
+	.blog &,
 	.archive & {
 		.wp-block-post-title {
 			margin-bottom: 10px;


### PR DESCRIPTION
Applies the same spacing to posts in the All Posts view that are used in category archive views. Also fixes an issue in the Community category archive view where posts with a featured image appear to be slightly truncated at the bottom of the square.

| Category spacing | All Posts spacing |
| --- | --- |
| ![category-spacing](https://user-images.githubusercontent.com/916023/153485868-f5107cb4-1107-40b7-85e7-6aecd116b5af.jpg) | ![all-posts-spacing](https://user-images.githubusercontent.com/916023/153485897-f6d75bd4-c417-4655-a75f-b0cafebaaa5a.jpg) |

Fixes #296 