### PR TITLE
Allow the `last-in-year` class to be added to the first post.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -216,12 +216,16 @@ function specify_post_classes( $classes, $extra_classes, $post_id ) {
 		}
 
 		if ( ! is_null( $current_post ) ) {
-			if ( 0 !== $current_post && $current_post < $count_posts - 1 ) {
+			if ( $current_post < $count_posts - 1 ) {
 				$this_year = date_create_from_format( 'Y-m-d H:i:s', get_the_date( 'Y-m-00 00:00:00' ) );
 				$next_year = date_create_from_format( 'Y-m-d H:i:s', get_the_date( 'Y-m-00 00:00:00', $wp_query->posts[ $current_post + 1 ] ) );
-				$prev_year = date_create_from_format( 'Y-m-d H:i:s', get_the_date( 'Y-m-00 00:00:00', $wp_query->posts[ $current_post - 1 ] ) );
+				$prev_year = false;
 
-				if ( $this_year->format( 'Y' ) !== $prev_year->format( 'Y' ) ) {
+				if ( $current_post >= 1 ) {
+					$prev_year = date_create_from_format( 'Y-m-d H:i:s', get_the_date( 'Y-m-00 00:00:00', $wp_query->posts[ $current_post - 1 ] ) );
+				}
+
+				if ( $prev_year && $this_year->format( 'Y' ) !== $prev_year->format( 'Y' ) ) {
 					$classes[] = 'first-in-year';
 				}
 


### PR DESCRIPTION
Fixes #301

Testing instructions:

 - Have the first post in the loop be the last post of a year.
 - visit /category/month-in-wordpress/
 - See the first post followed by a separator, followed by last years posts.

<img width="1728" alt="Screen Shot 2022-02-11 at 2 16 36 pm" src="https://user-images.githubusercontent.com/767313/153536785-4103ce92-559e-4acb-9d01-1c94d9a0d5f8.png">