### PR TITLE
Homepage: Fix font sizes on homepage

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
@@ -9,7 +9,7 @@ body.news-front-page .front__latest-posts {
 	}
 
 	.front__latest-posts-heading {
-		font-size: clamp(20px, calc(100vw / 24), 45px);
+		font-size: clamp(38px, 4vw, 50px);
 		line-height: 1;
 		margin-bottom: var(--wp--custom--alignment--edge-spacing);
 		padding: var(--wp--custom--alignment--edge-spacing) 0;
@@ -50,7 +50,7 @@ body.news-front-page .front__latest-posts {
 		}
 
 		h3 {
-			font-size: clamp(40px, calc(100vw / 24), 60px);
+			font-size: var(--wp--custom--h-2--typography--font-size);
 			margin-bottom: 15px;
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -31,7 +31,7 @@ body.news-front-page .front__latest-release {
 
 	// The "Latest Release" headline
 	.front__latest-release-heading {
-		font-size: clamp(20px, calc(100vw / 24), 45px);
+		font-size: clamp(38px, 4vw, 50px);
 		line-height: 1;
 		padding: var(--wp--custom--alignment--edge-spacing) 0;
 		width: calc(var(--wp--custom--layout--content-meta-size) - 32px);

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -3,8 +3,8 @@ body.news-front-page .front__people-of-wordpress {
 	position: relative;
 
 	.front__people-of-wordpress-heading {
-		font-size: clamp(20px, calc(100vw / 24), 45px);
-		padding: calc(var(--wp--custom--alignment--edge-spacing) * 2 ) var(--wp--custom--alignment--edge-spacing);
+		font-size: clamp(38px, 4vw, 50px);
+		padding: calc(var(--wp--custom--alignment--edge-spacing) * 2) var(--wp--custom--alignment--edge-spacing);
 
 		@include break-medium() {
 			padding: var(--wp--custom--alignment--edge-spacing);

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -240,7 +240,7 @@
 				"breakpoint": {
 					"mobile": {
 						"typography": {
-							"fontSize": "50px"
+							"fontSize": "clamp(26px, 4vw, 50px)"
 						}
 					}
 				},


### PR DESCRIPTION
Fixes #302. The "Latest Posts" etc headers are too small, and the post heading size is too large, compared to the original design. These elements weren't using the correct min & max values in the `clamp` function.

Before

| 400 | 960 | 1400 |
|-----|-----|------|
| ![before-home-400](https://user-images.githubusercontent.com/541093/153631217-69745f9c-5660-4ebf-bcb1-da7d7aac0131.png) | ![before-home-960](https://user-images.githubusercontent.com/541093/153631219-05827d02-8d1f-402c-bda5-e5d87dddc32f.png) | ![before-home-1400](https://user-images.githubusercontent.com/541093/153631229-a3b0bb6c-e66e-4190-9c99-6a1f0fee0895.png) |

After

| 400 | 960 | 1400 |
|-----|-----|------|
| ![after-home-400](https://user-images.githubusercontent.com/541093/153631200-61f26e73-aca3-4c1b-9423-014ef5b0903f.png) | ![after-home-960](https://user-images.githubusercontent.com/541093/153631206-c6456b0d-5c91-4174-b8d4-cdc9f0a7a4e0.png) | ![after-home-1400](https://user-images.githubusercontent.com/541093/153631209-f0c7d46a-b760-4356-9c44-32d78646093e.png) |

<details>
<summary>Original mockup</summary>

![design-home](https://user-images.githubusercontent.com/541093/153631778-97d823b7-198a-4a1e-9881-ad3cd35ca2fc.png) ![design-home-mobile](https://user-images.githubusercontent.com/541093/153631782-5a4daca8-c224-469c-b1c6-5020cf6fc8b0.png)

</details>