### PR TITLE
Home: Add brushstrokes to "See all…" links on small screens

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
@@ -56,30 +56,33 @@ body.news-front-page .front__latest-posts {
 	}
 
 	.front__next-page {
+		position: relative;
 		font-size: var(--wp--preset--font-size--small);
-		padding: 0 0 var(--wp--custom--alignment--edge-spacing) 0;
+		padding: 0;
+		margin-bottom: var(--wp--custom--alignment--edge-spacing);
 
 		@include break-medium() {
 			position: absolute;
 			bottom: var(--wp--custom--alignment--edge-spacing);
 			left: var(--wp--custom--alignment--edge-spacing);
 			padding: 0;
+			margin-bottom: 0;
+		}
 
-			&::before {
-				content: "";
-				display: block;
-				height: 115px;
-				width: 233px;
-				background-image: url(images/brush-stroke-see-all-posts.svg);
-				position: absolute;
-				top: calc(50% - (115px / 2));
-				left: -70px;
-			}
+		&::before {
+			content: "";
+			display: block;
+			height: 115px;
+			width: 233px;
+			background-image: url(images/brush-stroke-see-all-posts.svg);
+			position: absolute;
+			top: calc(50% - (115px / 2));
+			left: -70px;
+		}
 
-			a {
-				position: relative;
-				z-index: 1;
-			}
+		a {
+			position: relative;
+			z-index: 1;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -115,7 +115,7 @@ body.news-front-page .front__people-of-wordpress {
 			background-image: url(images/brush-stroke-see-all-people.svg);
 			position: absolute;
 			top: calc(var(--wp--custom--alignment--edge-spacing) - 1em);
-			left: 1em;
+			left: 0;
 
 			@include break-medium() {
 				top: calc(50% - (62px / 2));

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -92,34 +92,40 @@ body.news-front-page .front__people-of-wordpress {
 	}
 
 	.front__next-page {
+		position: relative;
 		font-size: var(--wp--preset--font-size--small);
 		padding:
 			var(--wp--custom--alignment--edge-spacing)
 			var(--wp--custom--alignment--edge-spacing)
 			calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--style--block-gap));
-		width: 192px;
 
 		@include break-medium() {
 			padding: 0 var(--wp--custom--alignment--edge-spacing) 0 0;
 			position: absolute;
 			top: var(--wp--custom--alignment--edge-spacing);
 			right: 0;
+			width: 192px;
+		}
 
-			&::before {
-				content: "";
-				display: block;
-				height: 62px;
-				width: 192px;
-				background-image: url(images/brush-stroke-see-all-people.svg);
-				position: absolute;
+		&::before {
+			content: "";
+			display: block;
+			height: 62px;
+			width: 192px;
+			background-image: url(images/brush-stroke-see-all-people.svg);
+			position: absolute;
+			top: calc(var(--wp--custom--alignment--edge-spacing) - 1em);
+			left: 1em;
+
+			@include break-medium() {
 				top: calc(50% - (62px / 2));
 				left: -20px;
 			}
+		}
 
-			a {
-				position: relative;
-				z-index: 1;
-			}
+		a {
+			position: relative;
+			z-index: 1;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #298 — The "See All Posts" & "See All People" links were missing the background brush strokes on small screens, this brings them back for all screen sizes.

Small screen:
<img width="495" alt="" src="https://user-images.githubusercontent.com/541093/153648153-cf331faa-07df-4fab-ae66-e3e7de68ca04.png">

No change on larger screens:
![](https://user-images.githubusercontent.com/541093/153648000-9009ef47-7bef-4f28-932a-31c1cff18917.png)
