### PR TITLE
Adjust front page header brush stroke to avoid horizontal scrollbar

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
@@ -27,7 +27,7 @@ body.news-front-page {
 			top: calc(35% - 65px);
 			left: 180px;
 			height: 130px;
-			width: calc(100vw - 180px);
+			width: calc(100vw - 200px);
 			z-index: -1;
 			background-color: var(--wp--preset--color--blue-2);
 			mask-image: url(images/brush-stroke-big.svg);


### PR DESCRIPTION
Reducing the width slightly (imperceptibly) eliminates the unwanted scrollbar.

Fixes #253 