### PR TITLE
Community Category: Set a 3-line maximum on post titles.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -173,8 +173,10 @@ body.category-community {
 	}
 
 	.wp-block-post-title {
-		font-size: var(--wp--preset--font-size--huge);
+		font-size: clamp(26px, 2vw, 32px);
 		line-height: 1.3;
+		max-height: 3.9em;
+		overflow: hidden;
 
 		a:hover,
 		a:focus {

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -175,8 +175,13 @@ body.category-community {
 	.wp-block-post-title {
 		font-size: clamp(26px, 2vw, 32px);
 		line-height: 1.3;
-		max-height: 3.9em; // 3 lines: 3em * 1.3 line height.
-		overflow: hidden;
+
+		a {
+			display: -webkit-box;
+			-webkit-box-orient: vertical;
+			-webkit-line-clamp: 3;
+			overflow: hidden;
+		}
 
 		a:hover,
 		a:focus {

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -175,7 +175,7 @@ body.category-community {
 	.wp-block-post-title {
 		font-size: clamp(26px, 2vw, 32px);
 		line-height: 1.3;
-		max-height: 3.9em;
+		max-height: 3.9em; // 3 lines: 3em * 1.3 line height.
 		overflow: hidden;
 
 		a:hover,

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -190,10 +190,7 @@ body.category-community {
 
 	li.post {
 		margin: 0;
-
-		@include break-small() {
-			aspect-ratio: 1 / 1;
-		}
+		aspect-ratio: 1 / 1;
 
 		.entry-meta {
 			padding: 24px;
@@ -212,12 +209,14 @@ body.category-community {
 					height: 100%;
 				}
 			}
+
 			// B&W featured image
 			.wp-block-post-featured-image {
 				object-fit: cover;
 
 				img {
 					filter: grayscale(100%);
+					aspect-ratio: 1 / 1;
 				}
 			}
 


### PR DESCRIPTION
Fix #300 — this sets a max-height of 3 lines for the post title, and hides the rest. It also adjusts the font size to be 26px at 960px wide, and scales up to 32px from there.

~It doesn't add any sort of ellipsis to indicate the title is cut off - I tried adding one as `after` content but it sits at the end of the text (cut off), and tried absolute positioning, but then it always sits at the bottom right regardless of where the end of the line is horizontally. I thought this solution was enough improvement to make a PR, though.~ With `line-clamp`, now it does add the ellipsis 🙂 

![960](https://user-images.githubusercontent.com/541093/153910206-291ba246-79d5-4638-8572-c369045f09f1.png)

<details>
<summary>More screenshots at different sizes</summary>

480
![480](https://user-images.githubusercontent.com/541093/153910186-95073d02-2295-4021-94c1-9363f6e51aba.png)

650
![650](https://user-images.githubusercontent.com/541093/153910195-031ead37-1273-4b07-90ca-86a9db573d5b.png)

790
![790](https://user-images.githubusercontent.com/541093/153910201-da0832f5-9e4a-4145-bba1-3efbf473e8ec.png)

1280
![1280](https://user-images.githubusercontent.com/541093/153910210-82a535f5-ca48-4356-a975-e3c4b1ff8c40.png)

1440
![1440](https://user-images.githubusercontent.com/541093/153910212-c6749561-9240-45d4-9fee-403b1756ec43.png)

</details>

To test:

- View the community category across sizes.
- The post titles shouldn't overflow out of the square, and they shouldn't visible clip (cut off) either.
