### PR TITLE
Center the podcast social icons to fix alignment

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_wp-briefing.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_wp-briefing.scss
@@ -31,20 +31,24 @@
 
 }
 
-.wp-briefing__apple-podcasts a {
-	background-image: url(images/podcast-services/apple-podcasts.svg);
-}
+.wp-block-social-link-anchor {
+	background-position: center;
 
-.wp-briefing__google-podcasts a {
-	background-image: url(images/podcast-services/google-podcasts.svg);
-}
+	.wp-briefing__apple-podcasts & {
+		background-image: url(images/podcast-services/apple-podcasts.svg);
+	}
 
-.wp-briefing__pocket-casts a {
-	background-image: url(images/podcast-services/pocket-casts.svg);
-}
+	.wp-briefing__google-podcasts & {
+		background-image: url(images/podcast-services/google-podcasts.svg);
+	}
 
-.wp-briefing__stitcher a {
-	background-image: url(images/podcast-services/stitcher.svg);
+	.wp-briefing__pocket-casts & {
+		background-image: url(images/podcast-services/pocket-casts.svg);
+	}
+
+	.wp-briefing__stitcher & {
+		background-image: url(images/podcast-services/stitcher.svg);
+	}
 }
 
 body.single-podcast {
@@ -59,19 +63,19 @@ body.single-podcast {
 			background-image: url(images/brush-stroke-short-2-dark-4.svg);
 		}
 
-		.wp-briefing__apple-podcasts a {
+		.wp-briefing__apple-podcasts .wp-block-social-link-anchor {
 			background-image: url(images/podcast-services/apple-podcasts-light.svg);
 		}
 
-		.wp-briefing__google-podcasts a {
+		.wp-briefing__google-podcasts .wp-block-social-link-anchor {
 			background-image: url(images/podcast-services/google-podcasts-light.svg);
 		}
 
-		.wp-briefing__pocket-casts a {
+		.wp-briefing__pocket-casts .wp-block-social-link-anchor {
 			background-image: url(images/podcast-services/pocket-casts-light.svg);
 		}
 
-		.wp-briefing__stitcher a {
+		.wp-briefing__stitcher .wp-block-social-link-anchor {
 			background-image: url(images/podcast-services/stitcher-light.svg);
 		}
 	}


### PR DESCRIPTION
The podcast icons were aligned to the upper left corner of their containers instead of the center.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/916023/154139909-faf501fc-f03a-4c45-811d-253053ed6bbb.jpg) | ![after](https://user-images.githubusercontent.com/916023/154139918-93e67f49-8570-4b87-89a2-540b56f0c684.jpg) |

Fixes #316 