### PR TITLE
 404: Offset "oops" to match design

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-templates/404.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/404.html
@@ -14,7 +14,7 @@
 	<p>
 		Go to
 		<a href="https://wordpress.org/news/">the homepage</a>,
-		or try searching News posts from the field below.
+		or try searching News posts using the field below.
 	</p>
 	<!-- /wp:paragraph -->
 

--- a/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
@@ -4,7 +4,6 @@
 	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
-	margin-top: -(var(--wp-admin--admin-bar--height, 0));
 
 	> .site-content-container {
 		// Make the content area grow to fill any remaining space on the screen, so that the footer is pushed to

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_query-title-banner.scss
@@ -3,12 +3,12 @@
 	color: var(--wp--preset--color--white);
 	position: relative;
 	z-index: -1;
-	background: linear-gradient(to top, transparent 58px, var(--wp--preset--color--blue-1) 58px 100%);
+	background: linear-gradient(to top, transparent var(--local-header-height), var(--wp--preset--color--blue-1) var(--local-header-height) 100%);
 	transform: translateY(-80px);
 
 	&::after {
 		content: "";
-		min-height: 58px;
+		min-height: var(--local-header-height);
 		position: absolute;
 		bottom: 1px;
 		left: 0;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
@@ -1,9 +1,7 @@
 html[lang] {
-
 	@include break-small {
-		// 58px = height of the local nav.
-		scroll-padding-top: calc(var(--wp-global-header-offset, 0px) + 58px);
-		margin-top: calc(var(--wp-global-header-offset, 0px) + 58px);
+		margin-top: calc(var(--wp-global-header-offset, 0px) + var(--local-header-height));
+		scroll-padding-top: calc(var(--wp-global-header-offset, 0px) + var(--local-header-height));
 	}
 }
 

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
@@ -4,7 +4,7 @@
 	.local-header__breadcrumb {
 		display: flex;
 		align-items: center;
-		min-height: var(--bar-min-height);
+		min-height: var(--local-header-height);
 		color: var(--bar-text-color);
 
 		// The current item is highlighted.

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
@@ -69,7 +69,7 @@
 		user-select: none;
 		margin: 0;
 		padding: 0 12px;
-		min-height: var(--bar-min-height);
+		min-height: var(--local-header-height);
 		position: absolute;
 		top: 0;
 		right: 9px;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
@@ -1,18 +1,22 @@
+:root {
+	--local-header-height: 58px;
+}
+
 .local-header {
-	--bar-min-height: 58px;
+
 	--bar-text-color: var(--wp--preset--color--white);
 	--bar-link-color: var(--wp--preset--color--white);
 	--bar-link-hover-color: var(--wp--preset--color--off-white-2);
 	--bar-background-color: var(--wp--preset--color--blue-1);
 
 	color: var(--bar-text-color);
-	min-height: var(--bar-min-height);
+	min-height: var(--local-header-height);
 	position: relative;
-	background: linear-gradient(to top, transparent var(--bar-min-height), var(--bar-background-color) var(--bar-min-height) 100%);
+	background: linear-gradient(to top, transparent var(--local-header-height), var(--bar-background-color) var(--local-header-height) 100%);
 
 	&::after {
 		content: "";
-		min-height: var(--bar-min-height);
+		min-height: var(--local-header-height);
 		position: absolute;
 		bottom: 1px;
 		left: 0;

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_404.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_404.scss
@@ -1,7 +1,5 @@
 body.error404 {
-	// The min is a "magic number" ala https://css-tricks.com/fitting-text-to-a-container/.
-	// The max prevents it from bleeding into the footer.
-	--oops-font-size: min(39vw, 48vh);
+	--oops-font-size: 47vw; // "Magic number" ala https://css-tricks.com/fitting-text-to-a-container/
 
 	background-color: var(--wp--preset--color--dark-grey);
 
@@ -14,21 +12,41 @@ body.error404 {
 	}
 
 	.site-content-container {
+		/*
+		 * Prevent "oops" from creating a horizontal scroll.
+		 * In some iOS versions, these rules also have to be applied to <html>, but that would bleed over to other
+		 * pages. It's better to just let there be a scroll, since it's not a commonly used page.
+		 */
+		position: relative; // needed for overflow to work
+		overflow: hidden;
+		min-height: var(--oops-font-size);
+		margin-top: 0;
 		color: var(--wp--preset--color--off-white-2);
 		padding-left: var(--wp--custom--alignment--edge-spacing);
 		padding-right: var(--wp--custom--alignment--edge-spacing);
+
+		@include break-small() {
+			// <html> has a `margin-top` that assumes the local header is present. That creates a gap when when
+			// hide the local nav. We can't change <html> without affecting other pages, so instead we just push
+			// this element up to cover the gap.
+			top: calc(-1 * var(--local-header-height));
+		}
 	}
 
 	.error404__oops {
 		z-index: -1;
 		position: absolute;
-		top: calc(var(--wp-global-header-offset) + var(--wp--style--block-gap));
-		left: 50%;
-		transform: translate(-50%, 0);
+		top: 14px;
+		left: -4.9vw;
 		font-family: var(--wp--preset--font-family--eb-garamond);
 		color: var(--wp--preset--color--darker-grey);
 		font-size: var(--oops-font-size);
 		line-height: var(--oops-font-size);
+
+		@include break-small() {
+			top: calc(var(--oops-font-size) * -0.23);
+			opacity: 0.6; // Make the overlaid text more readable.
+		}
 	}
 
 	h1 {
@@ -38,8 +56,8 @@ body.error404 {
 		line-height: 40px;
 
 		@include break-small() {
-			// Keep it stuck to rougly the same position on top of "Oops" as the viewport grows.
-			margin-top: calc(var(--oops-font-size) * 0.35);
+			// Keep it stuck to roughly the same position on top of "Oops" as the viewport grows.
+			margin-top: calc(var(--oops-font-size) * 0.31);
 			font-size: 70px;
 			line-height: 72px;
 		}
@@ -50,12 +68,16 @@ body.error404 {
 		text-decoration: underline;
 	}
 
-	.wp-block-search.wp-block-search__button-inside {
-		max-width: 400px;
+	.site-content-container .wp-block-search.wp-block-search__button-inside {
+		width: 100%;
 		margin-top: 40px;
 		padding: 16px 17px 16px 19px;
 		background-color: var(--wp--preset--color--white);
 		border-radius: var(--wp--custom--button--border--radius);
+
+		@include break-small() {
+			max-width: 400px;
+		}
 
 		.wp-block-search__inside-wrapper {
 			border: none;


### PR DESCRIPTION
Fixes #311

Follow up to #314. 

* Moves "oops" to be partially off screen.
* removes an invalid `margin-top` that wasn't affecting anything
* standardizes the local header height var
* adds specificity to the search form styles, to prevent them bleeding into the global header search

The black footer logo is just something off in my environment (also on `trunk`). I don't think it'll affect staging/prod.

![Screen Shot 2022-02-16 at 09 08 47-fullpage](https://user-images.githubusercontent.com/484068/154318484-36d92a8b-4236-41b1-9dd2-a698314aa998.png)

![Screen Shot 2022-02-16 at 09 08 57-fullpage](https://user-images.githubusercontent.com/484068/154318511-c3789605-2db7-438a-be9b-612afa48d3c6.png)
