### PR TITLE
Latest Posts list: Adjust gap between items

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
@@ -38,11 +38,9 @@ body.news-front-page .front__latest-posts {
 		}
 
 		> li {
-			margin-bottom: calc(var(--wp--custom--alignment--edge-spacing) * 2);
+			margin-bottom: clamp( 48px, calc( 100vw / 16 ), 58px );
 
 			@include break-medium() {
-				margin-bottom: calc(var(--wp--custom--alignment--edge-spacing) / 2);
-
 				&:last-child {
 					margin-bottom: 0;
 				}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
@@ -38,7 +38,7 @@ body.news-front-page .front__latest-posts {
 		}
 
 		> li {
-			margin-bottom: clamp( 48px, calc( 100vw / 16 ), 58px );
+			margin-bottom: clamp( 48px, 6.25vw, 58px );
 
 			@include break-medium() {
 				&:last-child {


### PR DESCRIPTION
This tries to better match the design by setting the gap to 58px on
desktop and 48px on mobile, with a slight variable range between those
two on intermediate screen widths.

Fixes #318