### PR TITLE
Homepage People of WordPress: Match hover/focus effects used on the Community archive page

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -402,7 +402,7 @@ body.category-community {
 				min-height: 0;
 
 				&:nth-of-type(even):hover,
-				&:nth-of-type(odd):hover
+				&:nth-of-type(odd):hover,
 				&:nth-of-type(even):focus-within,
 				&:nth-of-type(odd):focus-within {
 					transition: all 0.3s ease-in-out;

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -347,7 +347,6 @@ body.category-community {
 			figure,
 			figure a,
 			img {
-
 				@include break-small() {
 					height: 100%;
 				}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -33,22 +33,6 @@ body.news-front-page .front__people-of-wordpress {
 				width: calc(25% - 2px);
 			}
 
-			.wp-block-post-featured-image img {
-				filter: grayscale(100%);
-				position: absolute;
-				top: 0;
-				left: 0;
-				height: 100%;
-				width: 100%;
-				object-fit: cover;
-				transition: filter 0.15s linear;
-			}
-
-			&:hover .wp-block-post-featured-image img,
-			&:focus-within .wp-block-post-featured-image img {
-				filter: grayscale(0%);
-			}
-
 			&:focus-within {
 				outline: 1px dotted currentColor;
 			}
@@ -73,8 +57,32 @@ body.news-front-page .front__people-of-wordpress {
 
 			&.has-post-thumbnail {
 				.wp-block-post-title {
-
 					@include hide-accessibly;
+				}
+
+				// B&W featured image
+				.wp-block-post-featured-image {
+					margin: 0;
+
+					img {
+						object-fit: cover;
+						filter: grayscale(100%);
+						aspect-ratio: 1 / 1;
+					}
+				}
+
+				@include break-small() {
+					&:hover,
+					&:focus-within {
+						figure {
+							transition: all 0.3s ease-in-out;
+							background-color: var(--wp--preset--color--blue-1);
+						}
+
+						img {
+							mix-blend-mode: multiply;
+						}
+					}
 				}
 			}
 
@@ -84,7 +92,8 @@ body.news-front-page .front__people-of-wordpress {
 
 				&:hover,
 				&:focus-within {
-					background: var(--wp--preset--color--blue-2);
+					transition: all 0.3s ease-in-out;
+					background-color: var(--wp--preset--color--black);
 				}
 			}
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -77,7 +77,7 @@ body.news-front-page .front__people-of-wordpress {
 						mix-blend-mode: multiply;
 					}
 
-					.wp-block-post-title {
+					.wp-block-post-title a {
 						opacity: 1;
 						transition: opacity 0.3s ease-in-out;
 					}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -83,7 +83,7 @@ body.news-front-page .front__people-of-wordpress {
 					}
 				}
 
-				.wp-block-post-title {
+				.wp-block-post-title a {
 					opacity: 0;
 				}
 			}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -56,11 +56,6 @@ body.news-front-page .front__people-of-wordpress {
 			}
 
 			&.has-post-thumbnail {
-				.wp-block-post-title {
-					@include hide-accessibly;
-				}
-
-				// B&W featured image
 				.wp-block-post-featured-image {
 					margin: 0;
 
@@ -70,19 +65,26 @@ body.news-front-page .front__people-of-wordpress {
 						aspect-ratio: 1 / 1;
 					}
 				}
-
-				@include break-small() {
-					&:hover,
-					&:focus-within {
-						figure {
-							transition: all 0.3s ease-in-out;
-							background-color: var(--wp--preset--color--blue-1);
-						}
-
-						img {
-							mix-blend-mode: multiply;
-						}
+				
+				&:hover,
+				&:focus-within {
+					figure {
+						transition: all 0.3s ease-in-out;
+						background-color: var(--wp--preset--color--blue-1);
 					}
+
+					img {
+						mix-blend-mode: multiply;
+					}
+
+					.wp-block-post-title {
+						opacity: 1;
+						transition: opacity 0.3s ease-in-out;
+					}
+				}
+
+				.wp-block-post-title {
+					opacity: 0;
 				}
 			}
 


### PR DESCRIPTION
Syncs the color and transition effects of the post grid items on the Community archive page over to the grid items in the People of WordPress section of the homepage. It also ensures the post titles on grid items that have featured images are revealed on hover/focus, also like the Community archive page.

Fixes #267 
Refs #254 
