### PR TITLE
Use post-author-name block so name is linkable, link to wporg profile

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/content-page.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/content-page.html
@@ -5,7 +5,7 @@
 		<!-- wp:group {"className":"entry-meta"} -->
 		<div class="wp-block-group entry-meta">
 			<!-- wp:post-date /-->
-			By <!-- wp:post-author {"showAvatar":false} /-->
+			By <!-- wp:post-author-name {"isLink":true} /-->
 		</div>
 		<!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/content-single.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/content-single.html
@@ -5,7 +5,7 @@
 		<!-- wp:group {"className":"entry-meta"} -->
 		<div class="wp-block-group entry-meta">
 			<!-- wp:post-date /-->
-			By <!-- wp:post-author {"showAvatar":false} /-->
+			By <!-- wp:post-author-name {"isLink":true} /-->
 			in <!-- wp:post-terms {"term":"category"} /-->
 		</div>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
@@ -5,7 +5,7 @@
 	<!-- wp:group {"className":"entry-meta"} -->
 	<div class="wp-block-group entry-meta">
 		<!-- wp:post-date /-->
-		By <!-- wp:post-author {"showAvatar":false} /-->
+		By <!-- wp:post-author-name {"isLink":true} /-->
 		in Podcast
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -25,6 +25,7 @@ add_filter( 'the_title', __NAMESPACE__ . '\update_the_title', 10, 2 );
 add_action( 'ssp_album_art_cover', __NAMESPACE__ . '\custom_default_album_art_cover', 10, 2 );
 add_filter( 'render_block', __NAMESPACE__ . '\customize_podcast_player_position', null, 2 );
 add_filter( 'wp_list_categories', __NAMESPACE__ . '\add_links_to_categories_list', 10, 2 );
+add_filter( 'author_link', __NAMESPACE__ . '\use_wporg_profile_for_author_link', 10, 3 );
 add_action( 'parse_query', __NAMESPACE__ . '\compat_workaround_core_55100' );
 
 /**
@@ -374,6 +375,22 @@ function add_links_to_categories_list( $html, $args ) {
 	ksort( $links );
 
 	return implode( "\n\t", $links );
+}
+
+/**
+ * Swap out the normal author archive link for the author's wp.org profile link.
+ *
+ * @param string $link            Overwritten.
+ * @param int    $author_id       Unused.
+ * @param string $author_nicename Used as the slug in the profiles URL.
+ *
+ * @return string
+ */
+function use_wporg_profile_for_author_link( $link, $author_id, $author_nicename ) {
+	return sprintf(
+		'https://profiles.wordpress.org/%s/',
+		$author_nicename
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-author-name.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-author-name.scss
@@ -1,3 +1,3 @@
-.wp-block-post-author__name {
+.wp-block-post-author__link {
 	font-weight: var(--wp--custom--post-author--font-weight);
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-author-name.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-author-name.scss
@@ -1,3 +1,0 @@
-.wp-block-post-author__link {
-	font-weight: var(--wp--custom--post-author--font-weight);
-}

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
@@ -40,7 +40,7 @@
 			}
 		}
 
-		.wp-block-post-author,
+		.wp-block-post-author-name,
 		.wp-block-post-terms {
 			display: inline-block;
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/style.scss
@@ -38,7 +38,7 @@ GNU General Public License for more details.
 @import "blocks/image";
 @import "blocks/list";
 @import "blocks/paragraph";
-@import "blocks/post-author";
+@import "blocks/post-author-name";
 @import "blocks/post-comments";
 @import "blocks/post-excerpt";
 @import "blocks/post-title";

--- a/source/wp-content/themes/wporg-news-2021/sass/style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/style.scss
@@ -38,7 +38,6 @@ GNU General Public License for more details.
 @import "blocks/image";
 @import "blocks/list";
 @import "blocks/paragraph";
-@import "blocks/post-author-name";
 @import "blocks/post-comments";
 @import "blocks/post-excerpt";
 @import "blocks/post-title";

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -322,11 +322,6 @@
 					}
 				}
 			},
-			"post-author": {
-				"typography": {
-					"fontWeight": "normal"
-				}
-			},
 			"post-comment": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",


### PR DESCRIPTION
Swaps out the `post-author` block (which allows for showing the author's avatar, but not for linking to their archive), for the `post-author-name` block (which allows for linking, but not showing the avatar). We're not using the authors' avatars anyway. Then filters the `author_link` hook to replace the archive URL with the author's wp.org profile page URL.

This also removes some unused/unnecessary styles related to the `post-author` block.

Fixes #257