### PR TITLE
Update the line-height to use parent line-height.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_breadcrumbs.scss
@@ -12,6 +12,7 @@
 			font-family: var(--wp--preset--font-family--inter);
 			font-size: 1rem;
 			font-weight: 700;
+			line-height: inherit;
 
 			// This ensures that the square separator
 			// is reliably centered.


### PR DESCRIPTION
Super minor PR 😋. 

The breadcrumb is slighlty misaligned because the category is an `<h1>` which has a `line-height: var(--wp--custom--h-1--typography--line-height)` declaration. We can just inherit the parent to make it more aligned.

**Before**
![](https://d.pr/i/hJqOQP.png)

**After**
 ![](https://d.pr/i/6iNQwi.png)

**Testing**
- Visit `category/community/`
- Take a look at the alignment in the breadcrumb

