### PR TITLE
Link to the podcast category in single podcast.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
@@ -6,7 +6,7 @@
 	<div class="wp-block-group entry-meta">
 		<!-- wp:post-date /-->
 		By <!-- wp:post-author {"showAvatar":false} /-->
-		in Podcast
+		in <a href="/podcast">Podcast</a>
 	</div>
 	<!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
@@ -6,7 +6,7 @@
 	<div class="wp-block-group entry-meta">
 		<!-- wp:post-date /-->
 		By <!-- wp:post-author {"showAvatar":false} /-->
-		in <a href="/podcast">Podcast</a>
+		in <a href="/news/podcast">Podcast</a>
 	</div>
 	<!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
@@ -39,6 +39,9 @@ body.post-type-archive-podcast {
 			}
 		}
 
+		a {
+			color: var(--wp--preset--color--white);
+		}
 	}
 
 	.left-column {


### PR DESCRIPTION
This PR links the `Podcast` text to the `/news/podcast` URL. This is not a great approach especially because `news` is hard coded and our local dev doesn't serve out of a subfolder.

I'm getting this PR early to discuss the best approach. Is there a better way to link to urls in HTML templates?



