### PR TITLE
Community: Shift the post grid up under the local nav bar

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/local-navigation.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/local-navigation.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"align":"full","className":"local-header__navigation"} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"align":"full","className":"local-header__navigation"} -->
 <div class="wp-block-group alignfull local-header__navigation">
 	<!-- wp:group {"className":"local-header__breadcrumb"} -->
 	<div class="wp-block-group local-header__breadcrumb">

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
@@ -12,11 +12,12 @@ html[lang] {
 		position: revert;
 	}
 
+	z-index: 10;
+
 	@include break-small {
 		position: fixed;
 		top: var(--wp-admin--admin-bar--height, 0);
 		left: 0;
 		right: 0;
-		z-index: 10;
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -283,7 +283,7 @@ body.category-community {
 
 	.wp-site-blocks > .site-content-container:not(.site-header-container):not(.local-header):not(.global-footer):not(.bottom-banner) {
 		padding: 0;
-		margin-top: 0;
+		margin-top: calc(-1 * var(--local-header-height) / 3);
 
 		@include break-medium() {
 			padding-left: 0;


### PR DESCRIPTION
Fixes #320 — The local nav should overlap the community category slightly, so that there is no visible break of the tan page background.

| 400px | 800px | 1200px |
|-------|-------|--------|
| ![400](https://user-images.githubusercontent.com/541093/154531716-105dccd9-3f1e-4fde-a18e-88802c6d4502.png) | ![800](https://user-images.githubusercontent.com/541093/154531719-ebdcf8a6-90c4-474c-b62d-55b90a16c2e1.png) | ![1200](https://user-images.githubusercontent.com/541093/154531723-9aa9412b-42bf-48b2-a658-8c76e910f82e.png) |

To test

- View the community category at any screen size
- There should be no peak of tan under the local nav