### PR TITLE
Events category template

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category-events.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category-events.html
@@ -1,17 +1,11 @@
+<!-- wp:wporg/event-year /-->
+
 <!-- wp:group {"tagName":"header","className":"entry-header"} -->
 <header class="wp-block-group entry-header">
 	<!-- wp:post-title {"level":2,"isLink":true} /-->
 
-	<!-- wp:group {"className":"entry-meta"} -->
-	<div class="wp-block-group entry-meta">
-		<!-- wp:post-date /-->
-	</div>
-	<!-- /wp:group -->
+	<!-- wp:post-date /-->
 </header>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"section"} -->
-<section class="wp-block-group">
-	<!-- wp:post-excerpt {"moreText":"Read Post","showMoreOnNewLine":true,"layout":{"inherit":true}} /-->
-</section>
-<!-- /wp:group -->
+<!-- wp:post-excerpt {"moreText":"Read Post","showMoreOnNewLine":true,"layout":{"inherit":true}} /-->

--- a/source/wp-content/themes/wporg-news-2021/block-templates/category-events.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/category-events.html
@@ -2,7 +2,7 @@
 
 <!-- wp:query {"tagName":"main","className":"site-content-container"} -->
 <main class="wp-block-query site-content-container">
-	<!-- wp:post-template -->
+	<!-- wp:post-template {"align":"wide"} -->
 		<!-- wp:template-part {"slug":"content-category-events","tagName":"article","layout":{"inherit":true}} /-->
 	<!-- /wp:post-template -->
 
@@ -11,7 +11,6 @@
 		<!-- wp:query-pagination-numbers /-->
 		<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
 	<!-- /wp:query-pagination -->
-
 </main>
 <!-- /wp:query -->
 

--- a/source/wp-content/themes/wporg-news-2021/blocks/event-year/block.json
+++ b/source/wp-content/themes/wporg-news-2021/blocks/event-year/block.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/event-year",
+	"title": "WordPress.org Event Year",
+	"category": "widgets",
+	"icon": "calendar",
+	"description": "Show the year for an \"Events\" post.",
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"textAlign": {
+			"type": "string"
+		}
+	},
+	"usesContext": [ "postId" ],
+	"textdomain": "wporg"
+}

--- a/source/wp-content/themes/wporg-news-2021/blocks/event-year/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/event-year/index.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace WordPressdotorg\Theme\News_2021\Blocks\Event_Year;
+
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_type_js' );
+
+/**
+ * Renders the `wporg/event-year` block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the event year for the current post.
+ */
+function render_block( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_ID          = $block->context['postId'];
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
+
+	$year = '';
+	$post_year = get_the_date( 'Y', $post_ID );
+
+	/** @var \WP_Query $wp_query */
+	global $wp_query;
+	$current_page_post_dates = wp_list_pluck( $wp_query->posts, 'post_date', 'ID' );
+	array_reduce(
+		$wp_query->posts,
+		function( $carry, $item ) {
+			$year = get_the_date( 'Y', $item->ID );
+
+			if ( ! isset( $carry[ $year ] ) ) {
+				$carry[ $year ] = array();
+			}
+
+
+		},
+		array()
+	);
+
+
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$year
+	);
+}
+
+
+function get_current_post_ids_sorted_by_year() {
+	/** @var \WP_Query $wp_query */
+	global $wp_query;
+
+	array_reduce(
+		$wp_query->posts,
+		function( $carry, $item ) {
+			$year = get_the_date( 'Y', $item->ID );
+
+			if ( ! isset( $carry[ $year ] ) ) {
+				$carry[ $year ] = array();
+			}
+
+
+		},
+		array()
+	);
+}
+
+/**
+ * Registers the `wporg/event-year` block on the server.
+ */
+function register_block() {
+	register_block_type(
+		'wporg/event-year',
+		array(
+			'title'           => 'WordPress.org Event Year',
+			'render_callback' => __NAMESPACE__ . '\render_block',
+			'uses_context'    => [ 'postId' ],
+		)
+	);
+}
+
+/**
+ * Register block type in JS, for the editor.
+ */
+function register_block_type_js() {
+	$block = wp_json_file_decode( __DIR__ . '/block.json' );
+	ob_start();
+	?>
+	( function( wp ) {
+		wp.blocks.registerBlockType(
+			'<?php echo esc_js( $block->name ); ?>',
+			{
+				title: '<?php echo esc_js( $block->title ); ?>',
+				edit: function( props ) {
+					return wp.element.createElement( wp.serverSideRender, {
+						block: '<?php echo esc_js( $block->name ); ?>',
+						attributes: props.attributes
+					} );
+				},
+			}
+		);
+	}( window.wp ));
+	<?php
+	wp_add_inline_script( 'wp-editor', ob_get_clean(), 'after' );
+}

--- a/source/wp-content/themes/wporg-news-2021/blocks/event-year/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/event-year/index.php
@@ -19,56 +19,16 @@ function render_block( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$post_ID          = $block->context['postId'];
+	$post_ID = $block->context['postId'];
 	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
-	$year = '';
-	$post_year = get_the_date( 'Y', $post_ID );
-
-	/** @var \WP_Query $wp_query */
-	global $wp_query;
-	$current_page_post_dates = wp_list_pluck( $wp_query->posts, 'post_date', 'ID' );
-	array_reduce(
-		$wp_query->posts,
-		function( $carry, $item ) {
-			$year = get_the_date( 'Y', $item->ID );
-
-			if ( ! isset( $carry[ $year ] ) ) {
-				$carry[ $year ] = array();
-			}
-
-
-		},
-		array()
-	);
-
-
+	$year = get_the_date( 'Y', $post_ID );
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,
 		$year
-	);
-}
-
-
-function get_current_post_ids_sorted_by_year() {
-	/** @var \WP_Query $wp_query */
-	global $wp_query;
-
-	array_reduce(
-		$wp_query->posts,
-		function( $carry, $item ) {
-			$year = get_the_date( 'Y', $item->ID );
-
-			if ( ! isset( $carry[ $year ] ) ) {
-				$carry[ $year ] = array();
-			}
-
-
-		},
-		array()
 	);
 }
 

--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -6,6 +6,7 @@ use WP_Query;
 
 defined( 'WPINC' ) || die();
 
+require_once __DIR__ . '/blocks/event-year/index.php';
 require_once __DIR__ . '/blocks/month-in-wp-title/index.php';
 require_once __DIR__ . '/blocks/release-version/index.php';
 

--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -450,7 +450,7 @@ function print_events_category_archive_script() {
 		};
 
 		const eventHandler = ( event ) => {
-			const row = event.target;
+			const row = event.currentTarget;
 			const postYear = getPostYear( row );
 			const yearGroup = document.getElementsByClassName( postYear );
 
@@ -473,9 +473,9 @@ function print_events_category_archive_script() {
 			const postYear = getPostYear( row );
 
 			if ( postYear ) {
-				row.addEventListener( 'focus', eventHandler );
+				row.addEventListener( 'focus', eventHandler, { capture: true } );
 				row.addEventListener( 'mouseenter', eventHandler );
-				row.addEventListener( 'blur', eventHandler );
+				row.addEventListener( 'blur', eventHandler, { capture: true } );
 				row.addEventListener( 'mouseleave', eventHandler );
 			}
 		} );

--- a/source/wp-content/themes/wporg-news-2021/images/right-arrow-blue.svg
+++ b/source/wp-content/themes/wporg-news-2021/images/right-arrow-blue.svg
@@ -1,0 +1,4 @@
+<svg width="670" height="120" viewBox="0 0 670 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="6.55671e-08" y1="60" x2="669" y2="60.0001" stroke="#3e58e1" stroke-width="1.5"/>
+<path d="M609.928 1L668.928 60L609.928 119" stroke="#3e58e1" stroke-width="1.5"/>
+</svg>

--- a/source/wp-content/themes/wporg-news-2021/images/right-arrow-blue.svg
+++ b/source/wp-content/themes/wporg-news-2021/images/right-arrow-blue.svg
@@ -1,4 +1,4 @@
 <svg width="670" height="120" viewBox="0 0 670 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-<line x1="6.55671e-08" y1="60" x2="669" y2="60.0001" stroke="#3e58e1" stroke-width="1.5"/>
-<path d="M609.928 1L668.928 60L609.928 119" stroke="#3e58e1" stroke-width="1.5"/>
+<line x1="6.55671e-08" y1="60" x2="669" y2="60.0001" stroke="#213fd4" stroke-width="1.5"/>
+<path d="M609.928 1L668.928 60L609.928 119" stroke="#213fd4" stroke-width="1.5"/>
 </svg>

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_wporg-event-year.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_wporg-event-year.scss
@@ -3,6 +3,7 @@
 	font-size: 160px;
 	font-weight: 200;
 	line-height: 1;
+	letter-spacing: -10px;
 
 	@include break-medium() {
 		white-space: nowrap;

--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_wporg-event-year.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_wporg-event-year.scss
@@ -1,0 +1,10 @@
+.wp-block-wporg-event-year {
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: 160px;
+	font-weight: 200;
+	line-height: 1;
+
+	@include break-medium() {
+		white-space: nowrap;
+	}
+}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
@@ -1,4 +1,5 @@
 html[lang] {
+
 	@include break-small {
 		margin-top: calc(var(--wp-global-header-offset, 0px) + var(--local-header-height));
 		scroll-padding-top: calc(var(--wp-global-header-offset, 0px) + var(--local-header-height));

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_404.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_404.scss
@@ -12,6 +12,7 @@ body.error404 {
 	}
 
 	.site-content-container {
+
 		/*
 		 * Prevent "oops" from creating a horizontal scroll.
 		 * In some iOS versions, these rules also have to be applied to <html>, but that would bleed over to other

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -29,12 +29,10 @@ body.category-events {
 
 	.wp-block-post {
 		margin: 0;
-		padding:
-				var(--wp--custom--alignment--edge-spacing)
-				var(--wp--custom--alignment--edge-spacing);
+		padding: var(--row-padding-vertical) var(--wp--custom--alignment--edge-spacing);
 		position: relative;
 
-		&.first-in-year {
+		&.first-in-year:not(.first-year-of-page) {
 			padding-top: calc(var(--wp--custom--alignment--edge-spacing) * 1.5);
 		}
 
@@ -42,19 +40,13 @@ body.category-events {
 			padding-bottom: calc(var(--wp--custom--alignment--edge-spacing) * 1.5);
 		}
 
+		&.last-in-year:not(.first-year-of-page) {
+			padding-bottom: calc(160px + var(--wp--custom--alignment--edge-spacing));
+		}
+
 		// This is needed to position the version number so
 		// it appears "hidden".
 		overflow: hidden;
-
-		// Make some room for the version number on
-		// larger viewports.
-		@include break-medium() {
-			padding:
-					var(--row-padding-vertical)
-					var(--wp--custom--alignment--edge-spacing)
-					var(--row-padding-vertical)
-					calc(var(--wp--custom--layout--content-meta-size) + 32px + var(--wp--custom--alignment--edge-spacing));
-		}
 
 		// Reset the default block margins.
 		.wp-block-group.entry-header,
@@ -153,6 +145,26 @@ body.category-events {
 						transform: scale(0.6) translateX(0);
 					}
 				}
+			}
+		}
+	}
+
+	// This needs to be down here for some reason or the rules get overridden by the mobile ones.
+	@include break-medium() {
+		.wp-block-post {
+			padding:
+					var(--row-padding-vertical)
+					var(--wp--custom--alignment--edge-spacing)
+					var(--row-padding-vertical)
+					calc(var(--wp--custom--layout--content-meta-size) + 32px + var(--wp--custom--alignment--edge-spacing));
+
+			&.first-in-year:not(.first-year-of-page) {
+				padding-top: var(--wp--custom--alignment--edge-spacing);
+			}
+
+			&.first-year-of-page.last-in-year,
+			&.last-in-year:not(.first-year-of-page) {
+				padding-bottom: var(--wp--custom--alignment--edge-spacing);
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -3,6 +3,8 @@
  */
 
 body.category-events {
+	--row-padding-vertical: clamp( 24px, calc( 100vw / 26 ), 50px );
+
 	background-color: var(--wp--preset--color--off-white);
 
 	.local-header {
@@ -10,6 +12,106 @@ body.category-events {
 		--bar-text-color: var(--wp--preset--color--darker-grey);
 		--bar-link-color: var(--wp--preset--color--blue-1);
 		--bar-link-hover-color: var(--wp--preset--color--blue-5);
+	}
+
+	// This added specificity is needed to override the general
+	// layout styles for category templates.
+	.wp-site-blocks {
+		.site-content-container {
+			padding: 0 0 var(--wp--custom--alignment--edge-spacing);
+			display: block;
+		}
+	}
+
+	.wp-block-post-template {
+		margin: 0 0 var(--wp--custom--alignment--edge-spacing);
+	}
+
+	.wp-block-post {
+		margin: 0;
+		padding:
+				calc(var(--wp--custom--alignment--edge-spacing) * 1.5)
+				var(--wp--custom--alignment--edge-spacing)
+				calc(160px + var(--wp--custom--alignment--edge-spacing));
+		position: relative;
+
+		// This is needed to position the version number so
+		// it appears "hidden".
+		overflow: hidden;
+
+		// Make some room for the version number on
+		// larger viewports.
+		@include break-medium() {
+			padding:
+					var(--row-padding-vertical)
+					var(--wp--custom--alignment--edge-spacing)
+					var(--row-padding-vertical)
+					calc(var(--wp--custom--layout--content-meta-size) + 32px + var(--wp--custom--alignment--edge-spacing));
+		}
+
+		// Reset the default block margins.
+		.wp-block-group.entry-header,
+		.wp-block-post-title,
+		.wp-block-post-date {
+			margin: 0;
+		}
+
+		.wp-block-post-title {
+			font-size: var(--wp--custom--h-3--typography--font-size);
+		}
+
+		// Hide post excerpts by default.
+		.wp-block-post-excerpt {
+			display: none;
+		}
+
+		.wp-block-wporg-event-year {
+			position: absolute;
+			bottom: -30px;
+			color: var(--wp--preset--color--beige-2);
+			display: none;
+
+			@include break-medium() {
+				left: var(--wp--custom--alignment--edge-spacing);
+				width: calc(var(--wp--custom--layout--content-meta-size) - var(--wp--custom--alignment--edge-spacing));
+				transition: all 0.2s ease-in-out;
+			}
+		}
+
+		&.last-in-year {
+			border-bottom: 1px solid var(--wp--preset--color--beige-2);
+
+			&:not(.first-year-of-page) .wp-block-wporg-event-year {
+				display: block;
+			}
+		}
+
+		// The lastest release is shown first, and includes
+		// an excerpt and special styling.
+		&.first-year-of-page.first-in-year {
+			.wp-block-wporg-event-year {
+				display: block;
+				position: static;
+				padding-bottom: 0.3em;
+
+				@include break-medium() {
+					position: absolute;
+					bottom: auto;
+					top: var(--row-padding-vertical);
+				}
+			}
+
+			.wp-block-post-excerpt {
+				display: block;
+			}
+
+			.wp-block-post-excerpt__more-link {
+				&:hover,
+				&:focus {
+					text-decoration: none;
+				}
+			}
+		}
 	}
 }
 

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -30,10 +30,17 @@ body.category-events {
 	.wp-block-post {
 		margin: 0;
 		padding:
-				calc(var(--wp--custom--alignment--edge-spacing) * 1.5)
 				var(--wp--custom--alignment--edge-spacing)
-				calc(160px + var(--wp--custom--alignment--edge-spacing));
+				var(--wp--custom--alignment--edge-spacing);
 		position: relative;
+
+		&.first-in-year {
+			padding-top: calc(var(--wp--custom--alignment--edge-spacing) * 1.5);
+		}
+
+		&.first-year-of-page.last-in-year {
+			padding-bottom: calc(var(--wp--custom--alignment--edge-spacing) * 1.5);
+		}
 
 		// This is needed to position the version number so
 		// it appears "hidden".
@@ -81,8 +88,12 @@ body.category-events {
 		&.last-in-year {
 			border-bottom: 1px solid var(--wp--preset--color--beige-2);
 
-			&:not(.first-year-of-page) .wp-block-wporg-event-year {
-				display: block;
+			&:not(.first-year-of-page) {
+				padding-bottom: calc(160px + var(--wp--custom--alignment--edge-spacing));
+
+				.wp-block-wporg-event-year {
+					display: block;
+				}
 			}
 		}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -55,6 +55,10 @@ body.category-events {
 			margin: 0;
 		}
 
+		.wp-block-group.entry-header {
+			position: relative;
+		}
+
 		.wp-block-post-title {
 			font-size: var(--wp--custom--h-3--typography--font-size);
 		}
@@ -115,34 +119,40 @@ body.category-events {
 		}
 
 		@include break-medium() {
-			&:not(.first-year-of-page.first-in-year) {
-				.wp-block-post-title::after {
-					content: "";
-					display: block;
-					height: 118px;
-					min-width: 160px;
-					position: absolute;
-					top: calc(50% - (118px / 2));
-					right: 0;
-					opacity: 0;
-					transform: scale(0.6) translateX(-12px);
-					background-image: url(images/right-arrow-blue.svg);
-					background-position: center right;
-					background-repeat: no-repeat;
-					pointer-events: none;
-					transition: all 0.15s linear;
+			.wp-block-post-title::after {
+				content: "";
+				display: block;
+				height: 118px;
+				min-width: 160px;
+				position: absolute;
+				top: calc(50% - (118px / 2));
+				right: calc(-1 * var(--wp--custom--alignment--edge-spacing));
+				opacity: 0;
+				transform: scale(0.6) translateX(-12px);
+				background-image: url(images/right-arrow-blue.svg);
+				background-position: center right;
+				background-repeat: no-repeat;
+				pointer-events: none;
+				transition: all 0.15s linear;
+			}
+
+			&:hover,
+			&:focus-within {
+				.wp-block-wporg-event-year {
+					color: var(--wp--preset--color--blue-2);
 				}
 
+				.wp-block-post-title::after {
+					opacity: 1;
+					transform: scale(0.6) translateX(0);
+				}
+			}
+
+			&:not(.first-year-of-page.first-in-year) {
 				&:hover,
 				&:focus-within {
 					.wp-block-wporg-event-year {
-						color: var(--wp--preset--color--blue-1);
 						transform: translateY( calc( 0px - var(--row-padding-vertical) / 2 ) );
-					}
-
-					.wp-block-post-title::after {
-						opacity: 1;
-						transform: scale(0.6) translateX(0);
 					}
 				}
 			}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -138,19 +138,20 @@ body.category-events {
 
 			&:hover,
 			&:focus-within {
-				.wp-block-wporg-event-year {
-					color: var(--wp--preset--color--blue-2);
-				}
-
 				.wp-block-post-title::after {
 					opacity: 1;
 					transform: scale(0.6) translateX(0);
 				}
 			}
 
+			&.active {
+				.wp-block-wporg-event-year {
+					color: var(--wp--preset--color--blue-2);
+				}
+			}
+
 			&:not(.first-year-of-page.first-in-year) {
-				&:hover,
-				&:focus-within {
+				&.active {
 					.wp-block-wporg-event-year {
 						transform: translateY(calc(0px - var(--row-padding-vertical)));
 					}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -152,7 +152,7 @@ body.category-events {
 				&:hover,
 				&:focus-within {
 					.wp-block-wporg-event-year {
-						transform: translateY( calc( 0px - var(--row-padding-vertical) / 2 ) );
+						transform: translateY( calc( 0px - var(--row-padding-vertical) ) );
 					}
 				}
 			}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -86,8 +86,6 @@ body.category-events {
 			}
 		}
 
-		// The lastest release is shown first, and includes
-		// an excerpt and special styling.
 		&.first-year-of-page.first-in-year {
 			.wp-block-wporg-event-year {
 				display: block;
@@ -111,6 +109,53 @@ body.category-events {
 					text-decoration: none;
 				}
 			}
+		}
+
+		@include break-medium() {
+			&:not(.first-year-of-page.first-in-year) {
+				.wp-block-post-title::after {
+					content: "";
+					display: block;
+					height: 118px;
+					min-width: 160px;
+					position: absolute;
+					top: calc(50% - (118px / 2));
+					right: 0;
+					opacity: 0;
+					transform: scale(0.6) translateX(-12px);
+					background-image: url(images/right-arrow-blue.svg);
+					background-position: center right;
+					background-repeat: no-repeat;
+					pointer-events: none;
+					transition: all 0.15s linear;
+				}
+
+				&:hover,
+				&:focus-within {
+					.wp-block-wporg-event-year {
+						color: var(--wp--preset--color--blue-1);
+						transform: translateY( calc( 0px - var(--row-padding-vertical) / 2 ) );
+					}
+
+					.wp-block-post-title::after {
+						opacity: 1;
+						transform: scale(0.6) translateX(0);
+					}
+				}
+			}
+		}
+	}
+
+	.wp-block-query-pagination {
+		margin-left: var(--wp--custom--alignment--edge-spacing);
+		margin-right: var(--wp--custom--alignment--edge-spacing);
+
+		&::after {
+			background-color: var(--wp--preset--color--white);
+		}
+
+		@include break-medium() {
+			margin-left: calc(var(--wp--custom--layout--content-meta-size) + 32px + var(--wp--custom--alignment--edge-spacing));
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/_categories.scss
@@ -3,7 +3,7 @@
  */
 
 body.category-events {
-	--row-padding-vertical: clamp( 24px, calc( 100vw / 26 ), 50px );
+	--row-padding-vertical: clamp(24px, calc(100vw / 26), 50px);
 
 	background-color: var(--wp--preset--color--off-white);
 
@@ -152,7 +152,7 @@ body.category-events {
 				&:hover,
 				&:focus-within {
 					.wp-block-wporg-event-year {
-						transform: translateY( calc( 0px - var(--row-padding-vertical) ) );
+						transform: translateY(calc(0px - var(--row-padding-vertical)));
 					}
 				}
 			}
@@ -163,10 +163,10 @@ body.category-events {
 	@include break-medium() {
 		.wp-block-post {
 			padding:
-					var(--row-padding-vertical)
-					var(--wp--custom--alignment--edge-spacing)
-					var(--row-padding-vertical)
-					calc(var(--wp--custom--layout--content-meta-size) + 32px + var(--wp--custom--alignment--edge-spacing));
+				var(--row-padding-vertical)
+				var(--wp--custom--alignment--edge-spacing)
+				var(--row-padding-vertical)
+				calc(var(--wp--custom--layout--content-meta-size) + 32px + var(--wp--custom--alignment--edge-spacing));
 
 			&.first-in-year:not(.first-year-of-page) {
 				padding-top: var(--wp--custom--alignment--edge-spacing);
@@ -194,7 +194,7 @@ body.category-events {
 }
 
 body.category-releases {
-	--row-padding-vertical: clamp( 24px, calc( 100vw / 26 ), 50px );
+	--row-padding-vertical: clamp(24px, calc(100vw / 26), 50px);
 
 	background-color: var(--wp--preset--color--blue-1);
 
@@ -341,7 +341,7 @@ body.category-releases {
 				&:hover,
 				&:focus-within {
 					.wp-block-wporg-release-version {
-						transform: translateY( calc( 0px - var(--row-padding-vertical) / 2 ) );
+						transform: translateY(calc(0px - var(--row-padding-vertical) / 2));
 					}
 
 					.wp-block-post-title::after {
@@ -527,6 +527,7 @@ body.category-community {
 			figure,
 			figure a,
 			img {
+
 				@include break-small() {
 					height: 100%;
 				}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
@@ -38,7 +38,7 @@ body.news-front-page .front__latest-posts {
 		}
 
 		> li {
-			margin-bottom: clamp( 48px, 6.25vw, 58px );
+			margin-bottom: clamp(48px, 6.25vw, 58px);
 
 			@include break-medium() {
 				&:last-child {

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -65,7 +65,7 @@ body.news-front-page .front__people-of-wordpress {
 						aspect-ratio: 1 / 1;
 					}
 				}
-				
+
 				&:hover,
 				&:focus-within {
 					figure {

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -1,6 +1,6 @@
 .wp-block-post {
 	.blog &,
-	.category:not(.category-community):not(.category-releases) & {
+	.category:not(.category-community):not(.category-events):not(.category-releases) & {
 		padding-bottom: 20px;
 
 		@include break-mobile() {

--- a/source/wp-content/themes/wporg-news-2021/sass/style.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/style.scss
@@ -50,6 +50,7 @@ GNU General Public License for more details.
 @import "blocks/file";
 @import "blocks/table";
 @import "blocks/columns";
+@import "blocks/wporg-event-year";
 @import "blocks/wporg-month-in-wp-title";
 @import "blocks/wporg-release-version";
 

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -40,7 +40,12 @@
 				{
 					"slug": "beige",
 					"color": "#e4ddd4",
-					"name": "Beige"
+					"name": "Beige 1"
+				},
+				{
+					"slug": "beige-2",
+					"color": "#d3ccc3",
+					"name": "Beige 2"
 				},
 				{
 					"slug": "blue-1",


### PR DESCRIPTION
Implements the design for the Events category archive. Similar to the Releases archive, except that the "version" (year in this case) is only shown once for all of the posts in the given year, instead of for each post. This presents an extra challenge, since the query block output isn't filterable, so post list items from the same year can't be grouped into a container element.

The thing I haven't been able to figure out is how to have the year block animate and highlight when _any_ post in the year group is focused, rather than just the post that contains the visible year block. (See comment below with video showing desired behavior)

Fixes #281 

To test:

* If testing in the local dev environment, you'll need to add some extra posts in the Events category to really get a sense for it. The sample data doesn't have enough.
* You can also change the Reading settings to limit the posts shown per page to see how the year groupings work when split between pages.