### PR TITLE
Single Podcast: Add meta links to header

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-templates/archive-podcast.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/archive-podcast.html
@@ -41,10 +41,7 @@
 			</header>
 			<!-- /wp:group -->
 
-			<!-- wp:group {"className":"podcast-player"} -->
-			<div class="wp-block-group podcast-player">
-			</div>
-			<!-- /wp:group -->
+			<!-- wp:wporg/podcast-player /-->
 
 			<!-- wp:group {"tagName":"section"} -->
 			<section class="wp-block-group">

--- a/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
@@ -13,11 +13,7 @@
 	<!-- wp:group {"className":"podcast-title"} -->
 	<div class="wp-block-group podcast-title">
 		<!-- wp:post-title {"level":1} /-->
-		<!-- wp:group {"className":"podcast-player"} -->
-		<div class="wp-block-group podcast-player">
-		</div>
-		<!-- /wp:group -->
-
+		<!-- wp:wporg/podcast-player {"showMeta":true} /-->
 	</div>
 	<!-- /wp:group -->
 </header>

--- a/source/wp-content/themes/wporg-news-2021/blocks/podcast-player/block.json
+++ b/source/wp-content/themes/wporg-news-2021/blocks/podcast-player/block.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/podcast-player",
+	"title": "Podcast Player",
+	"category": "widgets",
+	"icon": "embed-audio",
+	"description": "Audio player for the current Podcast episode.",
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"showMeta": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+	"usesContext": [ "postId" ],
+	"textdomain": "wporg"
+}

--- a/source/wp-content/themes/wporg-news-2021/blocks/podcast-player/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/podcast-player/index.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace WordPressdotorg\Theme\News_2021\Blocks\Podcast_Player;
+
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_type_js' );
+
+/**
+ * Renders the `wporg/podcast-player` block on the server.
+ *
+ * This block is just a proxy on top of the Seriously Simple Podcast player, because that player requires
+ * a set post ID, while we want to always use the current post ID.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string
+ */
+function render_block( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_id = $block->context['postId'];
+	$output = do_blocks( '<!-- wp:seriously-simple-podcasting/castos-html-player {"episodeId":"' . $post_id . '"} /-->' );
+
+	$show_meta = isset( $attributes['showMeta'] ) && $attributes['showMeta'];
+
+	if ( $show_meta ) {
+		// Building this by hand rather than using `episode_meta_details()` to avoid confusing `title` attributes on links.
+		$ssp_controller = ssp_frontend_controller();
+
+		$download_url   = $ssp_controller->get_episode_download_link( $post_id );
+		$new_window_url = add_query_arg( 'ref', 'new_window', $download_url );
+
+		$download_link   = '<a href="' . esc_url( $download_url ) . '" class="podcast-meta-download">' . __( 'Download file', 'wporg' ) . '</a>';
+		$new_window_link = '<a href="' . esc_url( $new_window_url ) . '" target="_blank" class="podcast-meta-new-window">' . __( 'Play in new window', 'wporg' ) . '</a>';
+
+		$duration      = get_post_meta( $post_id, 'duration', true );
+		/* translators: %s duration of podcast episode. */
+		$duration_text = '<span class="podcast-meta-duration">' . sprintf( __( 'Duration: %s', 'wporg' ), esc_html( $duration ) ) . '</span>';
+
+		$output .= sprintf(
+			'<p class="podcast-player-meta">%s | %s | %s</p>',
+			$download_link,
+			$new_window_link,
+			$duration_text
+		);
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$output
+	);
+}
+
+/**
+ * Registers the `wporg/podcast-player` block on the server.
+ */
+function register_block() {
+	register_block_type(
+		__DIR__,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_block',
+		)
+	);
+}
+
+/**
+ * Register block type in JS, for the editor.
+ */
+function register_block_type_js() {
+	$block = wp_json_file_decode( __DIR__ . '/block.json' );
+	ob_start();
+	?>
+	( function( wp ) {
+		wp.blocks.registerBlockType(
+			'<?php echo esc_js( $block->name ); ?>',
+			{
+				title: '<?php echo esc_js( $block->title ); ?>',
+				edit: function( props ) {
+					return wp.element.createElement( wp.serverSideRender, {
+						block: '<?php echo esc_js( $block->name ); ?>',
+						attributes: props.attributes
+					} );
+				},
+			}
+		);
+	}( window.wp ));
+	<?php
+	wp_add_inline_script( 'wp-editor', ob_get_clean(), 'after' );
+}

--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -7,6 +7,7 @@ use WP_Query;
 defined( 'WPINC' ) || die();
 
 require_once __DIR__ . '/blocks/month-in-wp-title/index.php';
+require_once __DIR__ . '/blocks/podcast-player/index.php';
 require_once __DIR__ . '/blocks/release-version/index.php';
 
 /**
@@ -23,7 +24,6 @@ add_filter( 'render_block_data', __NAMESPACE__ . '\custom_query_block_attributes
 add_filter( 'template_redirect', __NAMESPACE__ . '\jetpack_likes_workaround' );
 add_filter( 'the_title', __NAMESPACE__ . '\update_the_title', 10, 2 );
 add_action( 'ssp_album_art_cover', __NAMESPACE__ . '\custom_default_album_art_cover', 10, 2 );
-add_filter( 'render_block', __NAMESPACE__ . '\customize_podcast_player_position', null, 2 );
 add_filter( 'wp_list_categories', __NAMESPACE__ . '\add_links_to_categories_list', 10, 2 );
 add_filter( 'author_link', __NAMESPACE__ . '\use_wporg_profile_for_author_link', 10, 3 );
 add_action( 'parse_query', __NAMESPACE__ . '\compat_workaround_core_55100' );
@@ -304,35 +304,6 @@ function custom_default_album_art_cover( $album_art ) {
 	}
 
 	return $album_art;
-}
-
-/**
- * Inserts the podcast player in a group block that has the 'podcast-player' or 'podcast-player-audio' class names
- * 'podcast-player' inserts the HTML5 player with album art
- * 'podcast-player-audio' inserts the standard compact player
- *
- * @param string $block_content The block content about to be appended.
- * @param array  $block          The full block, including name and attributes.
- *
- * @return string               The block content about to be appended.
- */
-function customize_podcast_player_position(
-	$block_content,
-	$block
-) {
-	if (
-		'core/group' === $block['blockName'] &&
-		! is_admin() &&
-		! wp_is_json_request()
-	) {
-		if ( isset( $block['attrs']['className'] ) ) {
-			if ( 'podcast-player' === $block['attrs']['className'] ) {
-				$block_content = do_blocks( '<!-- wp:seriously-simple-podcasting/castos-html-player {"episodeId":"' . get_the_ID() . '"} /-->' );
-			}
-		}
-	}
-
-	return $block_content;
 }
 
 /**

--- a/source/wp-content/themes/wporg-news-2021/sass/components/_podcast-player.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_podcast-player.scss
@@ -277,6 +277,21 @@
 	}
 }
 
+.wp-block-wporg-podcast-player {
+	.castos-player + .podcast-player-meta {
+		margin-top: var(--wp--style--block-gap);
+	}
+
+	.podcast-player-meta a {
+		text-decoration-line: underline;
+	}
+
+	.podcast-player-meta a:hover,
+	.podcast-player-meta a:focus {
+		text-decoration: none;
+	}
+}
+
 /* Reduced version of the player */
 .podcast-title {
 	.castos-player {


### PR DESCRIPTION
Fixes #338 — This PR switches the podcast player from using a group block that filters the render hook to using a custom block. This new block is just a proxy on top of the Seriously Simple Podcast player block, which is very similar to the render filter approach. The new block also has a `showMeta` attribute, to show the extra meta links, used on the single podcast page.

![](https://user-images.githubusercontent.com/541093/154583246-0115974e-3422-4824-b259-412a17dbe15a.png)

To test:

- View the podcast archive
- There should be players for each post, larger players on >768px, smaller on <=768px — no visible change from trunk
- Click into an episode
- There should be a small blue player in the header (no change to player), with meta info: download, new window, and duration (this part's new)
- Make sure the links work
