### PR TITLE
People of WP: Remove the link on the featured image.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/people-of-wordpress.html
@@ -5,7 +5,7 @@
 	<!-- /wp:heading -->
 
 	<!-- wp:post-template {"align":"full"} -->
-		<!-- wp:post-featured-image {"isLink":true} /-->
+		<!-- wp:post-featured-image /-->
 
 		<!-- wp:post-title {"level":3,"isLink":true} /-->
 	<!-- /wp:post-template -->


### PR DESCRIPTION
This removes the link on the featured image on the homepage People of WordPress section. The link on `post-title` is expanded to fill the whole square, so hovering over the image still generates the link. When tabbing through, now it only takes one tab per image+post, where before you had to tab twice, once for the image, once for the title, before moving through the page.

I tried to do the same on the Community grid, but had trouble. See #340

