### PR TITLE
Releases: Set query posts_per_page to 100

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -156,11 +156,14 @@ function override_category_query_args( $query ) {
 		return;
 	}
 	if ( $query->is_category() ) {
+		if ( $query->is_category( 'community' ) ) {
+			$query->set( 'posts_per_page', 20 );
+		}
 		if ( $query->is_category( 'month-in-wordpress' ) ) {
 			$query->set( 'posts_per_page', 600 );
 		}
-		if ( $query->is_category( 'community' ) ) {
-			$query->set( 'posts_per_page', 20 );
+		if ( $query->is_category( 'releases' ) ) {
+			$query->set( 'posts_per_page', 100 );
 		}
 	}
 }


### PR DESCRIPTION
Increasing the posts per page for this category makes it easier to browse all the release posts for particular versions.

Fixes #259