### PR TITLE
Remove link from featured image in community category post grid items

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category-community.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/content-category-community.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"tagName":"header","className":"entry-header",style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}}} -->
 <header class="wp-block-group entry-header">
-	<!-- wp:post-featured-image {"isLink":true,"width":"200","height":"200"} /-->
+	<!-- wp:post-featured-image {"width":"200","height":"200"} /-->
 
 	<!-- wp:group {"className":"entry-meta"} -->
 	<div class="wp-block-group entry-meta">


### PR DESCRIPTION
Removing the link improves accessibility by eliminating a redundant keypress when tabbing through the grid items. It does mean that less of the grid item is mouse-clickable for navigating to an individual post, but the post title is still prominent enough to provide an adequate click target. Notably, this also doesn't affect the visual hover effects when mousing over a grid item. This seems like a reasonable tradeoff to improve a11y.

Demo: https://d.pr/v/mqRe8i

Fixes #340