### PR TITLE
Remove underline offset until future date.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
@@ -3,6 +3,7 @@ a {
 	cursor: pointer;
 	text-decoration: none;
 	text-decoration-thickness: 1px;
+	text-underline-offset: 0.15em;
 
 	&:hover,
 	&:focus {

--- a/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
@@ -3,7 +3,6 @@ a {
 	cursor: pointer;
 	text-decoration: none;
 	text-decoration-thickness: 1px;
-	text-underline-offset: 0.15em;
 
 	&:hover,
 	&:focus {

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_local-header.scss
@@ -44,7 +44,7 @@
 
 		&:hover {
 			color: var(--bar-link-hover-color);
-			text-decoration: underline;
+			text-decoration-line: underline;
 		}
 	}
 }


### PR DESCRIPTION
Closes #347 

This bug seems to only affect **Chrome** and there is an open ticket:
https://bugs.chromium.org/p/chromium/issues/detail?id=1172623

This PR just removes the offset seeing that there is no ETA on when the bug will be closed.

I also don't think the line adds enough value to come up with a workaround.
