### PR TITLE
Scale font sizes for Releases/Events

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
@@ -16,6 +16,7 @@
 // styles for various sections of the site.
 // Read more here: https://sass-lang.com/documentation/style-rules/placeholder-selectors
 %two-column-grid-container {
+
 	@include break-wide() {
 		display: grid;
 		grid-template-columns: calc(var(--wp--custom--layout--content-meta-size) - 32px) auto;

--- a/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_layout.scss
@@ -16,12 +16,9 @@
 // styles for various sections of the site.
 // Read more here: https://sass-lang.com/documentation/style-rules/placeholder-selectors
 %two-column-grid-container {
-
 	@include break-wide() {
 		display: grid;
-		grid-template-columns:
-			calc(var(--wp--custom--layout--content-meta-size) - 32px)
-			auto;
+		grid-template-columns: calc(var(--wp--custom--layout--content-meta-size) - 32px) auto;
 
 		// This defines the minimum horizontal gap. An additional implicit gap is created because the right column
 		// contents have a `max-width` and are justified in the center.

--- a/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_bottom-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_bottom-banner.scss
@@ -10,15 +10,25 @@
 	margin-top: 0;
 	gap: 0;
 	background-color: var(--wp--preset--color--white);
-	line-height: 30px;
 
 	h3 {
-		font-size: 26px;
 		margin-bottom: var(--wp--custom--margin--baseline);
+		font-size: clamp(26px, 5.4vw, 36px);
+		line-height: 1.625;
+
+		@include break-medium() {
+			font-size: clamp(26px, 2.2vw, 36px);
+		}
 	}
 
 	h3 + p {
 		margin-top: 0;
+		line-height: 1.9;
+		font-size: clamp(var(--wp--preset--font-size--normal), 3.1vw, var(--wp--preset--font-size--extra-large));
+
+		@include break-medium() {
+			font-size: clamp(var(--wp--preset--font-size--normal), 1.3vw, var(--wp--preset--font-size--extra-large));
+		}
 	}
 
 	> .wp-block-group {

--- a/source/wp-content/themes/wporg-news-2021/sass/font-scaling.md
+++ b/source/wp-content/themes/wporg-news-2021/sass/font-scaling.md
@@ -1,0 +1,13 @@
+# Font Scaling
+
+This can be done by setting a value like `font-size: clamp( 30px, 5.8vw, 36px);`. The `clamp()` arguments will be different for each situation.
+
+1. Determine the minimum (a) and maximum (b) width of the container that the text is in.
+2. Determine the minimum (c) and maximum (d) font size that the text should have.
+3. Calculate the midpoint (e) of the container widths: ( a + b ) / 2
+4. Calculate the midpoint (f) of the font sizes: ( c + d ) / 2
+5. Size your browser so that the container width is `e`.
+6. Set `font-size: clamp( c, g, d );`, where `g` is a "magic number" ala https://css-tricks.com/fitting-text-to-a-container/
+7. Tweak `g` until the font size in the browser equals `f`.
+
+If the layout changes at a different breakpoint (e.g., switching from 1 column to 2), then repeat the process to get a new `font-size` value for that layout.

--- a/source/wp-content/themes/wporg-news-2021/sass/page/categories/_events.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/categories/_events.scss
@@ -1,4 +1,7 @@
 body.category-events {
+
+	@extend %scale-fonts-releases-events;
+
 	--row-padding-vertical: clamp(24px, calc(100vw / 26), 50px);
 
 	background-color: var(--wp--preset--color--off-white);
@@ -53,10 +56,6 @@ body.category-events {
 
 		.wp-block-group.entry-header {
 			position: relative;
-		}
-
-		.wp-block-post-title {
-			font-size: var(--wp--custom--h-3--typography--font-size);
 		}
 
 		// Hide post excerpts by default.

--- a/source/wp-content/themes/wporg-news-2021/sass/page/categories/_events.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/categories/_events.scss
@@ -75,6 +75,10 @@ body.category-events {
 				width: calc(var(--wp--custom--layout--content-meta-size) - var(--wp--custom--alignment--edge-spacing));
 				transition: all 0.2s ease-in-out;
 			}
+
+			@include break-huge() {
+				left: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
+			}
 		}
 
 		&.last-in-year {
@@ -157,8 +161,9 @@ body.category-events {
 	}
 
 	// This needs to be down here for some reason or the rules get overridden by the mobile ones.
-	@include break-medium() {
-		.wp-block-post {
+	.wp-block-post {
+
+		@include break-medium() {
 			padding:
 				var(--row-padding-vertical)
 				var(--wp--custom--alignment--edge-spacing)
@@ -173,6 +178,11 @@ body.category-events {
 			&.last-in-year:not(.first-year-of-page) {
 				padding-bottom: var(--wp--custom--alignment--edge-spacing);
 			}
+		}
+
+		@include break-huge() {
+			padding-left: calc(var(--wp--custom--layout--content-meta-size) + 32px + var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
+			padding-right: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/page/categories/_misc.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/categories/_misc.scss
@@ -24,7 +24,6 @@ body.category {
 			display: none;
 
 			@include break-wide() {
-
 				display: block;
 				margin-top: var(--wp--style--block-gap);
 			}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/categories/_misc.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/categories/_misc.scss
@@ -57,3 +57,43 @@ body.category-security {
 		--bar-link-hover-color: var(--wp--preset--color--darker-grey);
 	}
 }
+
+// Scale text to maintain a comfortable line length, regardless of viewport size.
+// This is specific to the type of layout that Releases and Events use.
+// See `sass/font-scaling.md` for details.
+%scale-fonts-releases-events {
+	.wp-block-post {
+		.wp-block-post-title {
+			max-width: var(--wp--custom--layout--content-size);
+			font-size: clamp(30px, 5.8vw, 36px);
+
+			@include break-medium() {
+				font-size: clamp(36px, 3.1vw, 50px);
+			}
+		}
+
+		.wp-block-post-date {
+
+			@include break-wide() {
+				font-size: var(--wp--preset--font-size--normal);
+			}
+		}
+
+		.wp-block-post-excerpt {
+			max-width: var(--wp--custom--layout--content-size);
+			font-size: clamp(var(--wp--preset--font-size--normal), 3.1vw, 20px);
+
+			@include break-medium() {
+				// The layout is now side-by side, so there isn't much room and we need a regular font size.
+				font-size: var(--wp--preset--font-size--normal);
+			}
+
+			@include break-xlarge() {
+				// There's enough room to scale the font again.
+				max-width: unset;
+
+				font-size: clamp(var(--wp--preset--font-size--normal), 1.3vw, var(--wp--preset--font-size--extra-large));
+			}
+		}
+	}
+}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/categories/_misc.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/categories/_misc.scss
@@ -1,4 +1,15 @@
-body {
+// Extra specificity to override default rules.
+body.archive.category {
+	.site-content-container {
+
+		@include break-huge() {
+			padding-left: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
+			padding-right: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
+		}
+	}
+}
+
+body.category {
 	--category-color: var(--wp--preset--color--blue-1);
 
 	.query-title-banner__title__dropcap {
@@ -19,7 +30,7 @@ body {
 			}
 
 			&::first-letter {
-				font-size: 35vw;
+				font-size: min(35vw, 475px); // Don't let this grow outside its container.
 				text-transform: uppercase;
 			}
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/categories/_releases.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/categories/_releases.scss
@@ -7,8 +7,7 @@ body.category-releases {
 		--bar-background-color: var(--wp--preset--color--blue-5);
 	}
 
-	// This added specificity is needed to override the general
-	// layout styles for category templates.
+	// This added specificity is needed to override the general layout styles for category templates.
 	.wp-site-blocks {
 		.site-content-container {
 			padding: 0 0 var(--wp--custom--alignment--edge-spacing);
@@ -20,8 +19,7 @@ body.category-releases {
 				color: var(--wp--preset--color--white);
 			}
 
-			// Make sure the pagination works with the category's
-			// blue background color.
+			// Make sure the pagination works with the category's blue background color.
 			.wp-block-query-pagination {
 				color: var(--wp--preset--color--white);
 
@@ -45,12 +43,10 @@ body.category-releases {
 		position: relative;
 		border-bottom: 1px solid var(--wp--preset--color--blue-5);
 
-		// This is needed to position the version number so
-		// it appears "hidden".
+		// This is needed to position the version number so it appears "hidden".
 		overflow: hidden;
 
-		// Make some room for the version number on
-		// larger viewports.
+		// Make some room for the version number on larger viewports.
 		@include break-medium() {
 			padding:
 				var(--row-padding-vertical)
@@ -96,8 +92,7 @@ body.category-releases {
 			}
 		}
 
-		// The latest release is shown first, and includes
-		// an excerpt and special styling.
+		// The latest release is shown first, and includes an excerpt and special styling.
 		&:first-child {
 			padding-bottom: calc(var(--wp--custom--alignment--edge-spacing) * 1.5);
 

--- a/source/wp-content/themes/wporg-news-2021/sass/page/categories/_releases.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/categories/_releases.scss
@@ -1,4 +1,7 @@
 body.category-releases {
+
+	@extend %scale-fonts-releases-events;
+
 	--row-padding-vertical: clamp(24px, calc(100vw / 26), 50px);
 
 	background-color: var(--wp--preset--color--blue-1);
@@ -65,10 +68,6 @@ body.category-releases {
 		.wp-block-post-title,
 		.wp-block-post-date {
 			margin: 0;
-		}
-
-		.wp-block-post-title {
-			font-size: var(--wp--custom--h-3--typography--font-size);
 		}
 
 		// Hide post excerpts by default.

--- a/source/wp-content/themes/wporg-news-2021/sass/page/categories/_releases.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/categories/_releases.scss
@@ -59,6 +59,11 @@ body.category-releases {
 				calc(var(--wp--custom--layout--content-meta-size) + 32px + var(--wp--custom--alignment--edge-spacing));
 		}
 
+		@include break-huge() {
+			padding-left: calc(var(--wp--custom--layout--content-meta-size) + 32px + var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
+			padding-right: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
+		}
+
 		// Reset the default block margins.
 		.wp-block-group.entry-header,
 		.wp-block-post-title,
@@ -85,9 +90,13 @@ body.category-releases {
 				width: calc(var(--wp--custom--layout--content-meta-size) - var(--wp--custom--alignment--edge-spacing));
 				transition: all 0.2s ease-in-out;
 			}
+
+			@include break-huge() {
+				left: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
+			}
 		}
 
-		// The lastest release is shown first, and includes
+		// The latest release is shown first, and includes
 		// an excerpt and special styling.
 		&:first-child {
 			padding-bottom: calc(var(--wp--custom--alignment--edge-spacing) * 1.5);

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_single.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_single.scss
@@ -1,8 +1,20 @@
 body.single,
 body.page {
-	.entry-header,
-	.wp-block-post-content {
-		padding-left: var(--wp--custom--alignment--edge-spacing);
-		padding-right: var(--wp--custom--alignment--edge-spacing);
+	.site-content-container {
+		.entry-header,
+		.wp-block-post-content {
+			padding-left: var(--wp--custom--alignment--edge-spacing);
+			padding-right: var(--wp--custom--alignment--edge-spacing);
+
+			@include break-huge() {
+				padding-left: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
+				padding-right: calc(var(--wp--custom--alignment--edge-spacing) + var(--wp--custom--alignment--outside-edge-extra-spacing));
+
+				> *.alignfull {
+					margin-left: calc(-1 * var(--wp--custom--alignment--edge-spacing) - var(--wp--custom--alignment--outside-edge-extra-spacing)) !important;
+					margin-right: calc(-1 * var(--wp--custom--alignment--edge-spacing) - var(--wp--custom--alignment--outside-edge-extra-spacing)) !important;
+				}
+			}
+		}
 	}
 }

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -108,7 +108,9 @@
 			"alignment": {
 				"alignedMaxWidth": "50%",
 				"//edge-spacing": "The min and max values represent the mobile and desktop spacing; the calc() value is for tablets.",
-				"edge-spacing": "clamp( 24px, calc( 100vw / 18 ), 80px )"
+				"edge-spacing": "clamp( 24px, calc( 100vw / 18 ), 80px )",
+				"//outside-edge-extra-spacing": "A separate variable is necessary here because `edge-spacing` isn't only used for the outer left/right edges.",
+				"outside-edge-extra-spacing": "7vw"
 			},
 			"button": {
 				"color": {


### PR DESCRIPTION
This adds some extra left/right edge padding on wide breakpoints, and scales the fonts across all breakpoints. [More screens are planned for the future](https://github.com/WordPress/wporg-news-2021/issues/39#issuecomment-1048617643), but these ones need it the most.

See #39

### Releases

Events has the same layout, so it is pretty much the same.

https://user-images.githubusercontent.com/484068/155572924-ff3a15d8-1319-42dd-baf5-f3a89d2177a4.mov

### Bottom Banner

I hid the content area to make it easier to see (otherwise the browser scrolls up and down a lot)


https://user-images.githubusercontent.com/484068/155573546-b655e158-1073-444a-9779-9715f9c0f46e.mov

### Footer

We may want to scale the global footer as well, since the difference here looks a bit odd:

<img width="1715" alt="Screen Shot 2022-02-24 at 9 13 59 AM" src="https://user-images.githubusercontent.com/484068/155573695-528a1a94-6e77-4265-8aad-60260f98ab7c.png">