### PR TITLE
Add Post type name block for Podcast link

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
+++ b/source/wp-content/themes/wporg-news-2021/block-templates/single-podcast.html
@@ -6,7 +6,7 @@
 	<div class="wp-block-group entry-meta">
 		<!-- wp:post-date /-->
 		By <!-- wp:post-author-name {"isLink":true} /-->
-		in Podcast
+		in <!-- wp:wporg/post-type-name { "isLink": true } /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/block.json
+++ b/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/block.json
@@ -4,7 +4,7 @@
 	"name": "wporg/post-type-name",
 	"title": "Post Type Name",
 	"category": "widgets",
-	"description": "Add the post type.",
+	"description": "Add the post type name.",
 	"supports": {
 		"html": false
 	},

--- a/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/block.json
+++ b/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/block.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/post-type-name",
+	"title": "Post Type Name",
+	"category": "widgets",
+	"icon": "embed-audio",
+	"description": "Add the post type.",
+	"supports": {
+		"html": false
+	},
+	"usesContext": [ "postId" ],
+	"textdomain": "wporg"
+}

--- a/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/block.json
+++ b/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/block.json
@@ -4,10 +4,19 @@
 	"name": "wporg/post-type-name",
 	"title": "Post Type Name",
 	"category": "widgets",
-	"icon": "embed-audio",
 	"description": "Add the post type.",
 	"supports": {
 		"html": false
+	},
+	"attributes": {
+		"tagName": {
+			"type": "string",
+			"default": "span"
+		},
+		"isLink": {
+			"type": "boolean",
+			"default": false
+		}
 	},
 	"usesContext": [ "postId" ],
 	"textdomain": "wporg"

--- a/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/index.php
@@ -48,17 +48,9 @@ function render_block( $attributes, $content, $block ) {
  */
 function register_block() {
 	register_block_type(
-		'wporg/post-type-name',
+		__DIR__ . '/block.json',
 		array(
-			'title'           => __( 'Post Type Name', 'wporg' ),
 			'render_callback' => __NAMESPACE__ . '\render_block',
-			'uses_context'    => array( 'postId' ),
-			'attributes'      => array(
-				'tagName' => array(
-					'default' => 'span',
-					'type'    => 'string',
-				),
-			),
 		)
 	);
 }

--- a/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/index.php
@@ -21,9 +21,9 @@ function render_block( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$post_id  = $block->context['postId'];
-	$post_type = get_post_type( $post_id );
-	$post_type_obj = get_post_type_object( $post_type );
+	$post_id            = $block->context['postId'];
+	$post_type          = get_post_type( $post_id );
+	$post_type_obj      = get_post_type_object( $post_type );
 	$wrapper_attributes = get_block_wrapper_attributes();
 
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
@@ -52,13 +52,13 @@ function register_block() {
 		array(
 			'title'           => __( 'Post Type Name', 'wporg' ),
 			'render_callback' => __NAMESPACE__ . '\render_block',
-			'uses_context'    => [ 'postId' ],
-			'attributes'    => [
-				'tagName' => [
+			'uses_context'    => array( 'postId' ),
+			'attributes'      => array(
+				'tagName' => array(
 					'default' => 'span',
-					'type' => 'string',
-				],
-			],
+					'type'    => 'string',
+				),
+			),
 		)
 	);
 }

--- a/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/index.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace WordPressdotorg\Theme\News_2021\Blocks\PostTypeName;
+
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_type_js' );
+
+/**
+ * Renders the `wporg/post-type-name` block on the server.
+ *
+ * The block render the post type name. It also optionally renders it as a link.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string
+ */
+function render_block( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_id  = $block->context['postId'];
+	$post_type = get_post_type( $post_id  );
+	$post_type_obj = get_post_type_object( $post_type );
+	$wrapper_attributes = get_block_wrapper_attributes();
+
+	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
+		return sprintf(
+			'<a %1$s href="%2$s">%3$s</a>',
+			$wrapper_attributes,
+			get_post_type_archive_link( $post_type ),
+			$post_type_obj->label,
+		);
+	}
+
+	return sprintf(
+		'<%1$s %2$s>%3$s</%1$s>',
+		$attributes['tagName'],
+		$wrapper_attributes,
+		$post_type_obj->label
+	);
+}
+
+/**
+ * Registers the `wporg/post-type-name` block on the server.
+ */
+function register_block() {
+	register_block_type(
+		'wporg/post-type-name',
+		array(
+			'title'           =>  __( 'Post Type Name', 'wporg' ),
+			'render_callback' => __NAMESPACE__ . '\render_block',
+			'uses_context'    => [ 'postId' ],
+			'attributes'	=> [
+				'tagName' => [
+					'default' => 'span',
+					'type' => 'string'
+				]
+			]
+		)
+	);
+}
+
+/**
+ * Register block type in JS, for the editor.
+ */
+function register_block_type_js() {
+	$block = wp_json_file_decode( __DIR__ . '/block.json' );
+	ob_start();
+	?>
+	( function( wp ) {
+		wp.blocks.registerBlockType(
+			'<?php echo esc_js( $block->name ); ?>',
+			{
+				title: '<?php echo esc_js( $block->title ); ?>',
+				edit: function( props ) {
+					return wp.element.createElement( wp.serverSideRender, {
+						block: '<?php echo esc_js( $block->name ); ?>',
+						attributes: props.attributes
+					} );
+				},
+			}
+		);
+	}( window.wp ));
+	<?php
+	wp_add_inline_script( 'wp-editor', ob_get_clean(), 'after' );
+}

--- a/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/post-type-name/index.php
@@ -22,7 +22,7 @@ function render_block( $attributes, $content, $block ) {
 	}
 
 	$post_id  = $block->context['postId'];
-	$post_type = get_post_type( $post_id  );
+	$post_type = get_post_type( $post_id );
 	$post_type_obj = get_post_type_object( $post_type );
 	$wrapper_attributes = get_block_wrapper_attributes();
 
@@ -50,15 +50,15 @@ function register_block() {
 	register_block_type(
 		'wporg/post-type-name',
 		array(
-			'title'           =>  __( 'Post Type Name', 'wporg' ),
+			'title'           => __( 'Post Type Name', 'wporg' ),
 			'render_callback' => __NAMESPACE__ . '\render_block',
 			'uses_context'    => [ 'postId' ],
-			'attributes'	=> [
+			'attributes'    => [
 				'tagName' => [
 					'default' => 'span',
-					'type' => 'string'
-				]
-			]
+					'type' => 'string',
+				],
+			],
 		)
 	);
 }

--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/blocks/event-year/index.php';
 require_once __DIR__ . '/blocks/month-in-wp-title/index.php';
 require_once __DIR__ . '/blocks/podcast-player/index.php';
 require_once __DIR__ . '/blocks/release-version/index.php';
+require_once __DIR__ . '/blocks/post-type-name/index.php';
 
 /**
  * Actions and filters.


### PR DESCRIPTION
This PR introduces a `post-type-name` component that renders the post type.


## Example
```
<!-- wp:wporg/post-type-name { "tagName": "h1", "isLink": true } /-->
```

## Screenshots
| Front End | Editor |
| --- | --- |
| <img src="https://d.pr/0Uheyx.png" width="400px"> | <img src="https://d.pr/i/3CvTBp.png" width="400px"> |



## Props

### tagName
A property that allows passing in the expected HTML tag to render the post type name in.

- Type: String
- Required: No
- Default: `span`



### isLink
If this property is true, the post type will be rendered as a link

- Type: Boolean
- Required: No
- Default: `false`


Related to #330 