### PR TITLE
Bump up the site header index.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/_site-header.scss
@@ -13,7 +13,7 @@ html[lang] {
 		position: revert;
 	}
 
-	z-index: 10;
+	z-index: 99;
 
 	@include break-small {
 		position: fixed;


### PR DESCRIPTION
Fixes #360 

This PR increases `.site-header-container` `z-index` from `10` to `99` to fix a bug where a component embedded in the main container is on top of the navigation.

I chose `99` since we will likely continue to use Gutenberg component and they typically keep their z-indexes below 100 for components that are not modals or menus. This of course cannot be guaranteed but should be relatively low risk. 

I decided not to bump it up to a larger number (ie: 10000) in case we make use of modal components or dropdowns in menus. `99` appears good enough for now.

Props @aniash29-cr