### PR TITLE
Update composer lock to fix broken environment.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2350,12 +2350,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "ee1995d3970487832dfc9261b30b85c094a115a1"
+                "reference": "5e3c41854a7f3dfc9bf9b7aefc226c2c8380b746"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/ee1995d3970487832dfc9261b30b85c094a115a1",
-                "reference": "ee1995d3970487832dfc9261b30b85c094a115a1",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/5e3c41854a7f3dfc9bf9b7aefc226c2c8380b746",
+                "reference": "5e3c41854a7f3dfc9bf9b7aefc226c2c8380b746",
                 "shasum": ""
             },
             "require": {
@@ -2382,7 +2382,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/trunk",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2022-02-14T18:18:57+00:00"
+            "time": "2022-03-18T16:58:01+00:00"
         },
         {
             "name": "wporg/wporg-repo-tools",


### PR DESCRIPTION
## Summary
This PR updates [`WordPress/wporg-mu-plugins`](https://github.com/WordPress/wporg-mu-plugins) to the latest to resolve the following error on fresh environment install:

```
✖ Error while running docker-compose command.
Creating 991de0e6541006e317f9c31bec815128_tests-cli_run ... 
Creating 991de0e6541006e317f9c31bec815128_tests-cli_run ... done
Warning: require_once(/var/www/html/wp-content/mu-plugins/wporg-mu-plugins/mu-plugins/loader.php): failed to open stream: No such file or directory in /var/www/html/wp-content/mu-plugins/0-sandbox.php on line 11
Fatal error: require_once(): Failed opening required '/var/www/html/wp-content/mu-plugins/wporg-mu-plugins/mu-plugins/loader.php' (include_path='.:/usr/local/lib/php') in /var/www/html/wp-content/mu-plugins/0-sandbox.php on line 11
Error: There has been a critical error on this website.Learn more about troubleshooting WordPress. There has been a critical error on this website.
```

This project requires [this commit](https://github.com/WordPress/wporg-mu-plugins/commit/096c46533e93a54ac9064f163e17f4ca23010ee5) from wporg-mu-plugins in order to align with [this commit ](https://github.com/WordPress/wporg-news-2021/commit/bebf4a47e0c3bfdcac2a3157cdfb0c20b0d82888) in this project.

## Changes
- Update to the latest since other changes appear relatively minor and shouldn't affect this theme adversely.

