### PR TITLE
Home: Use Release Version block to avoid overflow

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
@@ -7,7 +7,7 @@
 	<!-- wp:post-template -->
 		<!-- wp:group {"tagName":"header","className":"entry-header"} -->
 		<header class="wp-block-group entry-header">
-			<!-- wp:post-title {"level":3,"isLink":true} /-->
+			<!-- wp:wporg/release-version {"tagName":"h3","isLink":true} /-->
 
 			<!-- wp:group {"className":"entry-meta"} -->
 			<div class="wp-block-group entry-meta">

--- a/source/wp-content/themes/wporg-news-2021/blocks/event-year/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/event-year/index.php
@@ -37,11 +37,9 @@ function render_block( $attributes, $content, $block ) {
  */
 function register_block() {
 	register_block_type(
-		'wporg/event-year',
+		__DIR__ . '/block.json',
 		array(
-			'title'           => 'WordPress.org Event Year',
 			'render_callback' => __NAMESPACE__ . '\render_block',
-			'uses_context'    => [ 'postId' ],
 		)
 	);
 }

--- a/source/wp-content/themes/wporg-news-2021/blocks/release-version/block.json
+++ b/source/wp-content/themes/wporg-news-2021/blocks/release-version/block.json
@@ -10,6 +10,14 @@
 		"html": false
 	},
 	"attributes": {
+		"isLink": {
+			"type": "boolean",
+			"default": false
+		},
+		"tagName": {
+			"type": "string",
+			"default": "div"
+		},
 		"textAlign": {
 			"type": "string"
 		}

--- a/source/wp-content/themes/wporg-news-2021/blocks/release-version/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/release-version/index.php
@@ -2,6 +2,8 @@
 
 namespace WordPressdotorg\Theme\News_2021\Blocks\Release_Version;
 
+use WP_Block;
+
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_type_js' );
 
@@ -24,7 +26,7 @@ function render_block( $attributes, $content, $block ) {
 
 	$version = '';
 	$title = get_the_title( $post_ID );
-	// Do we also want x.y.z?
+
 	if ( preg_match( '/WordPress (\d{0,3}(?:\.\d{1,3})+)\s*(?|Release Candidate\s*(\d+)|RC\s*(\d+))?/', $title, $matches ) ) {
 		$version = $matches[1];
 		if ( ! empty( $matches[2] ) ) {
@@ -32,13 +34,13 @@ function render_block( $attributes, $content, $block ) {
 		}
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+	$wrapper_tag   = $attributes['tagName'] ?? 'div';
+	$wrapper_open  = "<$wrapper_tag " . get_block_wrapper_attributes( array( 'class' => $align_class_name ) ) . '>';
+	$link_open     = empty( $attributes['isLink'] ) ? '' : '<a href="' . get_permalink( $post_ID ) . '">';
+	$link_close    = empty( $attributes['isLink'] ) ? '' : '</a>';
+	$wrapper_close = "</$wrapper_tag>";
 
-	return sprintf(
-		'<div %1$s>%2$s</div>',
-		$wrapper_attributes,
-		$version
-	);
+	return "$wrapper_open $link_open $version $link_close $wrapper_close";
 }
 
 /**

--- a/source/wp-content/themes/wporg-news-2021/blocks/release-version/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/release-version/index.php
@@ -48,11 +48,9 @@ function render_block( $attributes, $content, $block ) {
  */
 function register_block() {
 	register_block_type(
-		'wporg/release-version',
+		__DIR__ . '/block.json',
 		array(
-			'title'           => 'WordPress.org Release Version',
 			'render_callback' => __NAMESPACE__ . '\render_block',
-			'uses_context'    => [ 'postId' ],
 		)
 	);
 }

--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -23,7 +23,6 @@ add_filter( 'body_class', __NAMESPACE__ . '\clarify_body_classes' );
 add_filter( 'post_class', __NAMESPACE__ . '\specify_post_classes', 10, 3 );
 add_filter( 'render_block_data', __NAMESPACE__ . '\custom_query_block_attributes' );
 add_filter( 'template_redirect', __NAMESPACE__ . '\jetpack_likes_workaround' );
-add_filter( 'the_title', __NAMESPACE__ . '\update_the_title', 10, 2 );
 add_action( 'ssp_album_art_cover', __NAMESPACE__ . '\custom_default_album_art_cover', 10, 2 );
 add_filter( 'wp_list_categories', __NAMESPACE__ . '\add_links_to_categories_list', 10, 2 );
 add_filter( 'author_link', __NAMESPACE__ . '\use_wporg_profile_for_author_link', 10, 3 );
@@ -267,23 +266,6 @@ function jetpack_likes_workaround() {
 	if ( is_callable( [ $jetpack_likes, 'load_styles_register_scripts' ] ) ) {
 		$jetpack_likes->load_styles_register_scripts();
 	}
-}
-
-/**
- * Remove "WordPress" from the release post title.
- *
- * @param string $title The post title.
- * @param int    $id    The post ID.
- * @return string Filtered post title.
- */
-function update_the_title( $title, $id ) {
-	// Remove "WordPress" from the post title in the Latest Release section on the front page.
-	$category_slugs = wp_list_pluck( get_the_category( $id ), 'slug' );
-	if ( is_front_page() && in_array( 'releases', $category_slugs ) ) {
-		return str_replace( 'WordPress', '', $title );
-	}
-
-	return $title;
 }
 
 /**

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-posts.scss
@@ -14,6 +14,7 @@ body.news-front-page .front__latest-posts {
 		margin-bottom: var(--wp--custom--alignment--edge-spacing);
 		padding: var(--wp--custom--alignment--edge-spacing) 0;
 		width: calc(var(--wp--custom--layout--content-meta-size) - 32px);
+		max-width: 100%;
 
 		@include break-medium() {
 			min-width: calc(var(--wp--custom--layout--content-meta-size) - 32px);

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -1,5 +1,4 @@
-// The "Latest Release" section which displays the
-// latest post in the releases category.
+// The "Latest Release" section which displays the latest post in the releases category.
 body.news-front-page .front__latest-release {
 	color: var(--wp--preset--color--white);
 	font-size: var(--wp--preset--font-size--small);
@@ -16,15 +15,13 @@ body.news-front-page .front__latest-release {
 	padding: var(--wp--custom--alignment--edge-spacing);
 
 	@include break-medium() {
-		// Display side-by-side when the viewport
-		// is big enough.
+		// Display side-by-side when the viewport is big enough.
 		flex-direction: row;
 		gap: 0;
 		padding: 0;
 	}
 
-	// Since we have a blue backround our links need
-	// to be white.
+	// Since we have a blue background our links need to be white.
 	a {
 		color: var(--wp--preset--color--white);
 	}
@@ -53,15 +50,13 @@ body.news-front-page .front__latest-release {
 		margin-top: 0;
 	}
 
-	// This allows us to ignore some of the underlying markup
-	// in order to make our layout work.
+	// This allows us to ignore some of the underlying markup in order to make our layout work.
 	.wp-block-post-template,
 	.wp-block-post-template .wp-block-post,
 	.wp-block-post-template .wp-block-group.entry-header {
 		display: contents;
 	}
 
-	// The release post title
 	.wp-block-post-title {
 		font-family: var(--wp--preset--font-family--inter);
 		font-size: 60px;
@@ -113,7 +108,6 @@ body.news-front-page .front__latest-release {
 		}
 	}
 
-	// The releast post date
 	.wp-block-post-date {
 		font-size: var(--wp--preset--font-size--small);
 
@@ -125,7 +119,7 @@ body.news-front-page .front__latest-release {
 			bottom: var(--wp--custom--alignment--edge-spacing);
 			left: calc((var(--wp--custom--layout--content-meta-size) - 32px) + (var(--wp--custom--alignment--edge-spacing) * 2));
 
-			// Avoid interferring with the large anchor link.
+			// Avoid interfering with the large anchor link.
 			pointer-events: none;
 		}
 	}
@@ -161,43 +155,6 @@ body.news-front-page .front__latest-release {
 			z-index: 1;
 
 			&:hover {
-				text-decoration: none;
-			}
-		}
-	}
-
-	.old--wp-block-post-template {
-		.wp-block-post-title {
-			--header-size: clamp(var(--wp--preset--font-size--huge), 13vw, 130px);
-
-			margin-bottom: var(--wp--custom--margin--vertical);
-			padding-right: var(--header-size);
-			background-image: url(images/right-arrow.svg);
-			background-size: var(--header-size);
-			background-repeat: no-repeat;
-			background-position: right center;
-			font-size: var(--header-size);
-			font-family: var(--wp--preset--font-family--inter);
-			font-weight: 200;
-			line-height: 1.1;
-		}
-	}
-
-	.old--front__next-page {
-
-		@include break-medium() {
-			border-right: 1px solid var(--wp--preset--color--blue-2);
-		}
-
-		&::after {
-			background-color: var(--wp--preset--color--blue-2);
-		}
-
-		a {
-			text-decoration: underline;
-
-			&:hover,
-			&:focus {
 				text-decoration: none;
 			}
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -11,7 +11,6 @@ body.news-front-page .front__latest-release {
 	// Setup the basic layout
 	display: flex;
 	flex-direction: column;
-	gap: 15px;
 	padding: var(--wp--custom--alignment--edge-spacing);
 
 	@include break-medium() {
@@ -37,7 +36,7 @@ body.news-front-page .front__latest-release {
 			margin-left: var(--wp--custom--alignment--edge-spacing);
 			min-width: calc(var(--wp--custom--layout--content-meta-size) - 32px);
 			padding:
-				var(--wp--custom--alignment--edge-spacing)
+				calc(var(--wp--custom--alignment--edge-spacing) + 15px)
 				calc(var(--wp--custom--alignment--edge-spacing) * 2)
 				calc(var(--wp--custom--alignment--edge-spacing) * 2)
 				0;
@@ -57,15 +56,18 @@ body.news-front-page .front__latest-release {
 		display: contents;
 	}
 
-	.wp-block-post-title {
+	.wp-block-wporg-release-version {
+		position: relative;
+		left: -8px; /* Justify with .front__latest-release-heading */
 		font-family: var(--wp--preset--font-family--inter);
-		font-size: 60px;
+		font-size: min(35vw, 130px);
 		font-weight: 200;
-		line-height: 1.1;
+		line-height: 1.2;
 
 		@include break-medium() {
+			left: unset;
 			flex-grow: 1;
-			font-size: 90px;
+			font-size: min(16vw, 160px);
 			padding:
 				calc(var(--wp--custom--alignment--edge-spacing) / 2)
 				var(--wp--custom--alignment--edge-spacing)
@@ -87,22 +89,24 @@ body.news-front-page .front__latest-release {
 				align-items: center;
 				z-index: 1;
 				height: 100%;
-				padding: 30px 0;
+				padding: 15px 0;
 				transition: background-color 0.15s linear;
 
-				&::after {
-					content: "";
-					display: block;
-					height: 118px;
-					min-width: 130px;
-					flex-grow: 1;
-					margin-left: 40px;
-					transform: scale(0.9);
-					background-image: url(images/right-arrow.svg);
-					background-position: center right;
-					background-repeat: no-repeat;
-					pointer-events: none;
-					transition: all 0.15s linear;
+				@include break-xlarge() {
+					&::after {
+						content: "";
+						display: block;
+						height: 118px;
+						min-width: 130px;
+						flex-grow: 1;
+						margin-left: 40px;
+						transform: scale(0.9);
+						background-image: url(images/right-arrow.svg);
+						background-position: center right;
+						background-repeat: no-repeat;
+						pointer-events: none;
+						transition: all 0.15s linear;
+					}
 				}
 			}
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -151,7 +151,11 @@ body.news-front-page .front__latest-release {
 			background-image: url(images/brush-stroke-see-all-releases.svg);
 			position: absolute;
 			top: calc(50% - (45px / 2));
-			left: calc(-116px / 2);
+			left: -20px;
+
+			@include break-medium() {
+				left: calc(-116px / 2);
+			}
 		}
 
 		a {

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -31,6 +31,7 @@ body.news-front-page .front__latest-release {
 		line-height: 1;
 		padding: var(--wp--custom--alignment--edge-spacing) 0;
 		width: calc(var(--wp--custom--layout--content-meta-size) - 32px);
+		max-width: 100%;
 
 		@include break-medium() {
 			margin-left: var(--wp--custom--alignment--edge-spacing);


### PR DESCRIPTION
Fixes #364 

The mockup calls for just the version number on the homepage, but originally we included the full title because of Gutenberg limitations. We built a custom block that will extract just the version number for the Releases category, so we can use it here too.

https://user-images.githubusercontent.com/484068/159569918-29f2102e-48b4-45ba-a1fb-2b36be7ec556.mov

cc @vijayhardaha