### PR TITLE
Remove css class that adds ellipses.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-excerpt.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/blocks/_post-excerpt.scss
@@ -1,11 +1,3 @@
-.wp-block-post-excerpt__excerpt {
-	// Add an ellipses so that excerpts are not just cut off mid-sentence.
-	// Necessary since we're making the "more text" a link on a separate line.
-	&::after {
-		content: "\2026";
-	}
-}
-
 .wp-block-post-excerpt__more-text {
 	a {
 		text-decoration: underline;


### PR DESCRIPTION
This PR removes CSS that adds ellipses to the post excerpt. 

See the associated issue for background. 

Fixes: #366 