### PR TITLE
Update the color for selected text

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_normalize.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_normalize.scss
@@ -8,13 +8,15 @@ body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 
-	// Text selection background color
+	// Text selection colors.
 	::selection {
-		background-color: var(--wp--preset--color--coral-red);
+		background-color: var(--wp--preset--color--off-white-2);
+		color: var(--wp--preset--color--black);
 	}
 
 	::-moz-selection {
-		background-color: var(--wp--preset--color--coral-red);
+		background-color: var(--wp--preset--color--off-white-2);
+		color: var(--wp--preset--color--black);
 	}
 }
 


### PR DESCRIPTION
Fixes #372. This switches the text selection color from coral red to light blue. It also forces the text color to be black when highlighted (against the light blue), since otherwise white text became unreadable.

**Screenshots**

<img width="734" alt="" src="https://user-images.githubusercontent.com/541093/167686371-1e7735fd-91b8-4201-816e-c342f9124d98.png">

<img width="735" alt="" src="https://user-images.githubusercontent.com/541093/167686369-8b09d432-74d0-4486-bf7b-cfa6377358b9.png">

<img width="306" alt="" src="https://user-images.githubusercontent.com/541093/167686372-f9794167-bfc9-440b-a6d2-f4e882c563aa.png">

<img width="406" alt="" src="https://user-images.githubusercontent.com/541093/167686374-8516c52f-39d7-4639-afb9-d937f9d4304d.png">

