### PR TITLE
Update CSS for Gutenberg 13.7

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
@@ -1,5 +1,5 @@
 // Links
-a {
+a:not(.wp-element-button) {
 	cursor: pointer;
 	text-decoration: none;
 	text-decoration-thickness: 1px;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_bottom-banner.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_bottom-banner.scss
@@ -4,7 +4,7 @@
 }
 
 // Default/light version.
-.bottom-banner-items[class*="wp-container-"] {
+.bottom-banner-items[class*="wp-block-"] {
 	justify-content: space-between;
 	align-items: stretch !important;
 	margin-top: 0;
@@ -74,7 +74,7 @@
 		border-color: #1c2024;
 	}
 
-	.bottom-banner .bottom-banner-items[class*="wp-container-"] {
+	.bottom-banner .bottom-banner-items[class*="wp-block-"] {
 		background-color: var(--wp--preset--color--dark-grey);
 		color: var(--wp--preset--color--white);
 		border-color: #1c2024;

--- a/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_subscribe-wp-news.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_subscribe-wp-news.scss
@@ -1,4 +1,4 @@
-.bottom-banner .bottom-banner-items[class*="wp-container-"] .subscribe-wp-news {
+.bottom-banner .bottom-banner-items[class*="wp-block-"] .subscribe-wp-news {
 	.jetpack_subscription_widget {
 		form {
 			display: grid;
@@ -55,7 +55,7 @@
 
 // Alternate dark version.
 %bottom-banner-dark {
-	.bottom-banner .bottom-banner-items[class*="wp-container-"] .subscribe-wp-news {
+	.bottom-banner .bottom-banner-items[class*="wp-block-"] .subscribe-wp-news {
 		#subscribe-email input {
 			background-color: var(--wp--preset--color--white);
 			color: var(--wp--preset--color--black);

--- a/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_wp-briefing.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/bottom-banner/_wp-briefing.scss
@@ -1,4 +1,4 @@
-.bottom-banner .bottom-banner-items[class*="wp-container-"] .wp-briefing {
+.bottom-banner .bottom-banner-items[class*="wp-block-"] .wp-briefing {
 	p {
 		margin-top: 0;
 		margin-bottom: 0;
@@ -65,7 +65,7 @@ body.single-podcast {
 }
 
 %bottom-banner-dark {
-	.bottom-banner .bottom-banner-items[class*="wp-container-"] .wp-briefing {
+	.bottom-banner .bottom-banner-items[class*="wp-block-"] .wp-briefing {
 		.podcast-link {
 			background-image: url(images/brush-stroke-short-2-dark-4.svg);
 		}

--- a/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/components/local-header/_categories.scss
@@ -98,7 +98,7 @@
 		max-height: none;
 
 		// Override the default margin applied to the block.
-		[class*="wp-container-"] & {
+		[class*="wp-block-"] & {
 			margin: 0;
 		}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_header.scss
@@ -1,5 +1,5 @@
 .entry-header {
-	&[class*="wp-container-"] * + * {
+	&[class*="wp-block-"] * + * {
 		margin-top: 0;
 	}
 


### PR DESCRIPTION
- The `wp-container-*` class is no longer added to all blocks, instead we should use the `wp-block-*` class. The selector is necessary for specificity, so we can't just remove it.
- Update default link selector — This matches the gutenberg default style, which was overriding the News style due to higher specificity.

| Before | After |
|-------|------|
| ![before-home](https://user-images.githubusercontent.com/541093/180315078-259c1b28-0258-4893-aa68-74287fea9536.png) | ![after-home](https://user-images.githubusercontent.com/541093/180315064-1ac4cece-6a0e-4490-9d89-b079961f07e4.png) |
| ![before-podcast](https://user-images.githubusercontent.com/541093/180315080-d14d1e88-e675-4fca-bbdc-d04b731c1b53.png) | ![after-podcast](https://user-images.githubusercontent.com/541093/180315077-50d9bd49-4041-4804-b706-4fa4cc89c345.png) |