### PR TITLE
Fix: People of WordPress image aspect ratio not working on safari 14 or less

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_people-of-wordpress.scss
@@ -63,6 +63,14 @@ body.news-front-page .front__people-of-wordpress {
 						object-fit: cover;
 						filter: grayscale(100%);
 						aspect-ratio: 1 / 1;
+
+						@supports not (aspect-ratio: 1 / 1) {
+							height: 100%;
+						}
+					}
+
+					@supports not (aspect-ratio: 1 / 1) {
+						height: 100%;
 					}
 				}
 


### PR DESCRIPTION
Fixes [389](https://github.com/WordPress/wporg-news-2021/issues/389)