### PR TITLE
Fixed the banner title size

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
@@ -40,6 +40,10 @@ body.post-type-archive-podcast {
 
 			span {
 				font-size: clamp(72px, 12vw, 150px);
+
+				@media (max-width: 380px) {
+                    font-size: clamp(62px, 12vw, 130px);
+                }
 			}
 		}
 


### PR DESCRIPTION
I have decreased the size of the banner title in mobile size and solved the issue.

![CleanShot 2022-09-23 at 15 00 24@2x](https://user-images.githubusercontent.com/72435501/191932077-17c87752-b63c-4f00-919a-72b671a4a97a.png)

Closes #392 