### PR TITLE
Update css for Content overflow issue in news category page

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_content.scss
@@ -2,6 +2,7 @@
 	.blog &,
 	.category:not(.category-community):not(.category-events):not(.category-releases) & {
 		padding-bottom: 20px;
+		word-break: break-word;
 
 		@include break-mobile() {
 			margin-bottom: 40px;


### PR DESCRIPTION
I have solved this issue which mentioned in #396 
In the responsive(below 480px) the content overflow is displayed on the https://wordpress.org/news/category/security/
For better understanding I provide the Video attachment Link:
Video link: https://share.cleanshot.com/ctJojcn1ZT9TPpk39qha