### PR TITLE
Add filter to disable sharing features.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/blocks/post-type-name/index.php';
 /**
  * Actions and filters.
  */
+add_action( 'init', __NAMESPACE__ . '\disable_jetpack_sharing' );
 add_action( 'after_setup_theme', __NAMESPACE__ . '\theme_support', 9 );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_filter( 'get_the_archive_title_prefix', __NAMESPACE__ . '\modify_archive_title_prefix' );
@@ -437,4 +438,13 @@ function add_block_styles() {
 	register_block_style( 'core/paragraph', $props_styles['short'] );
 	register_block_style( 'core/paragraph', $props_styles['medium'] );
 	register_block_style( 'core/paragraph', $props_styles['long'] );
+}
+
+/**
+ * Turns off Jetpack Social feature auto-share for posts.
+ *
+ * See: https://jetpack.com/support/jetpack-social/social-sharing-new-posts/
+ */
+function disable_jetpack_sharing() {
+	remove_post_type_support( 'post', 'publicize' );
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/wporg-news-2021/issues/408

This PR removes post type support for the JetPack auto sharing feature.
https://jetpack.com/support/jetpack-social/social-sharing-new-posts/