### PR TITLE
Updated css for Responsive Design 

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/categories/_community.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/categories/_community.scss
@@ -123,7 +123,7 @@ body.category-community {
 		&:not(.has-post-thumbnail) {
 			min-height: 25vh;
 			display: flex;
-			align-items: flex-end;
+			align-items: center;
 
 			@include break-small() {
 				min-height: 0;


### PR DESCRIPTION
URL : https://wordpress.org/news/category/community/
In Responsive size the section which doesn't have any featured image and has only text is aligned end so it is showing space at the top. So if we do align the centre then it will look better
Screenshot : https://drive.google.com/file/d/1Kdcp6qUFrU6WbI-8N_8OjbS3ucv-Ybgd/view?usp=sharing