### PR TITLE
Reduce the height of the homepage header.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
@@ -16,7 +16,6 @@ body.news-front-page {
 		z-index: 1;
 		background-color: var(--wp--preset--color--blue-1);
 		color: var(--wp--preset--color--white);
-		margin: var(--wp--custom--alignment--edge-spacing) 0 calc(var(--wp--custom--alignment--edge-spacing) * 2);
 		padding: var(--wp--custom--alignment--edge-spacing);
 		font-size: clamp(80px, 25vw, 160px);
 

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_front-page.scss
@@ -16,8 +16,13 @@ body.news-front-page {
 		z-index: 1;
 		background-color: var(--wp--preset--color--blue-1);
 		color: var(--wp--preset--color--white);
+		margin: 0 0 var(--wp--custom--alignment--edge-spacing);
 		padding: var(--wp--custom--alignment--edge-spacing);
 		font-size: clamp(80px, 25vw, 160px);
+
+		@media (min-width: 768px) {
+			margin: 0;
+		}
 
 		// Add and place the brush stroke
 		&::after {


### PR DESCRIPTION
Fixes #394.

This removes the margin from the header to bring more of the content into view. It doesn't completely match the design in the original issue. All those components are not present anymore or at least with the latest post.


| Before |  After |
|--------|--------|
|  ![localhost_8888_ (5)](https://github.com/WordPress/wporg-news-2021/assets/1657336/dbc7b269-9f03-4f8c-9491-456b8c42cb6c) | ![localhost_8888_ (3)](https://github.com/WordPress/wporg-news-2021/assets/1657336/50fc6d54-4fd4-4910-ba4c-5c9a2042c81a) | 


## Considerations

The "News" isn't completely centered in the top container because the subnav is the same color. That matches newer designs of developer.wordpress.org and documentation. Does that work? I can remove padding from the top of the section to make it even. Looks fine to me though.

