### PR TITLE
Enhance content wrapping

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss
@@ -1,3 +1,25 @@
+// Create balanced text blocks
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+caption,
+figcaption {
+	text-wrap: var(--wp--custom--heading--typography--text-wrap);
+	overflow-wrap: initial;
+	word-break: initial;
+}
+
+// Prevent orphans
+p,
+ul,
+ol,
+blockquote {
+	text-wrap: var(--wp--custom--body--typography--text-wrap);
+}
+
 // Links
 a:not(.wp-element-button) {
 	cursor: pointer;

--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -217,14 +217,16 @@
 			},
 			"body": {
 				"typography": {
-					"lineHeight": 1.9
+					"lineHeight": 1.9,
+					"textWrap": "pretty"
 				}
 			},
 			"heading": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontWeight": 400,
-					"lineHeight": 1.3
+					"lineHeight": 1.3,
+					"textWrap": "balance"
 				}
 			},
 			"h1": {


### PR DESCRIPTION
Fixes #406 

This PR follows [the approach we've taken in the parent theme](https://github.com/WordPress/wporg-parent-2021/pull/119), enhancing content wrapping by:

1. Creating balanced headings and captions with `text-wrap: balanced`
2. Preventing orphans in paragraphs, lists and blockquotes with `text-wrap: pretty`

### Screenshots

| Size | Before | After |
|-|-|-|
| Desktop | ![wordpress org_news_2023_07_synced-patterns-the-evolution-of-reusable-blocks_(1 1920x1080)](https://github.com/WordPress/wporg-news-2021/assets/1017872/6907c8c8-a887-471a-a4b1-aa8a6703f8a3) | ![wordpress org_news_2023_07_synced-patterns-the-evolution-of-reusable-blocks_(1 1920x1080) (1)](https://github.com/WordPress/wporg-news-2021/assets/1017872/33f87359-9fe6-459d-871e-4432471bd55b) |
| | ![wordpress org_news_2023_07_wordpress-6-3-live-product-demo-highlights-recording_(1 1920x1080) (1)](https://github.com/WordPress/wporg-news-2021/assets/1017872/b44a6de0-1286-45bf-8960-f3548d6baec2) | ![wordpress org_news_2023_07_wordpress-6-3-live-product-demo-highlights-recording_(1 1920x1080)](https://github.com/WordPress/wporg-news-2021/assets/1017872/e8b03f62-ddcf-4c1f-8cbc-5eeb0b13cd86) |
| Tablet | ![wordpress org_news_2023_07_synced-patterns-the-evolution-of-reusable-blocks_(iPad)](https://github.com/WordPress/wporg-news-2021/assets/1017872/927a8036-e163-4545-8b3b-8ee5df0808ee) | ![wordpress org_news_2023_07_synced-patterns-the-evolution-of-reusable-blocks_(iPad) (1)](https://github.com/WordPress/wporg-news-2021/assets/1017872/80bad37f-ae02-40a8-8bd1-1d4822560a8c) |
| Mobile | ![wordpress org_news_2023_07_synced-patterns-the-evolution-of-reusable-blocks_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-news-2021/assets/1017872/315c97ea-3491-4721-9cac-b64872d50b84) | ![wordpress org_news_2023_07_synced-patterns-the-evolution-of-reusable-blocks_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/wporg-news-2021/assets/1017872/f966a333-b6c3-42a1-afda-953c05dd6a3e) |

### Testing

Resize the page observing the text wrapping on the affected elements.

The titles should remain balanced, with no orphans, until the screen is so narrow that the text has to wrap.

Paragraphs and lists should not have orphans until the screen is so narrow that the text has to wrap.

Check browsers that don't support the properties yet (at time of writing Firefox has only just added support for `balance`, but not `pretty`, and Safari has no support), they should gracefully degrade, ie. there should be no effect.
https://caniuse.com/?search=text-wrap%3Apretty
https://caniuse.com/?search=text-wrap%3Abalance


