### PR TITLE
Avoid a PHP Warning in the rest api

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/functions.php
+++ b/source/wp-content/themes/wporg-news-2021/functions.php
@@ -153,7 +153,7 @@ function clarify_body_classes( $classes ) {
  */
 function specify_post_classes( $classes, $extra_classes, $post_id ) {
 	global $wp_query;
-	if ( ! is_object( $wp_query ) ) {
+	if ( ! is_object( $wp_query ) || ! isset( $wp_query->posts ) ) {
 		return $classes;
 	}
 


### PR DESCRIPTION
```
E_WARNING: count(): Parameter must be an array or an object that implements Countable in wp-content/themes/wporg-news-2021/functions.php:162

Source: GET https://wordpress.org/news/wp-json/wp/v2/posts?per_page=1
File: wp-content/themes/wporg-news-2021/functions.php:162
```

Unsure why this has suddenly started, but the above PHP Warning is happening in the REST api fairly frequently.

Looking at the WP_Query object, it appears to be uninitialised, so this seems like a shortcut we can take to avoid it.. 