### PR TITLE
Update font sizes for podcast page.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
@@ -43,7 +43,7 @@ body.post-type-archive-podcast {
 			line-height: 1;
 
 			span {
-				font-size: clamp(50px, 12vw, 150px);
+				font-size: clamp(56px, 12vw, 150px);
 			}
 		}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
@@ -10,7 +10,7 @@ body.post-type-archive-podcast {
 		margin-top: calc(var(--wp--custom--margin--baseline) * -4);
 		position: relative;
 		padding-top: 80px;
-		padding-bottom: 100px;
+		padding-bottom: 80px;
 		padding-left: var(--wp--custom--alignment--edge-spacing);
 		padding-right: var(--wp--custom--alignment--edge-spacing);
 		color: var(--wp--preset--color--white);

--- a/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/post/_podcast.scss
@@ -10,10 +10,14 @@ body.post-type-archive-podcast {
 		margin-top: calc(var(--wp--custom--margin--baseline) * -4);
 		position: relative;
 		padding-top: 80px;
-		padding-bottom: 160px;
+		padding-bottom: 100px;
 		padding-left: var(--wp--custom--alignment--edge-spacing);
 		padding-right: var(--wp--custom--alignment--edge-spacing);
 		color: var(--wp--preset--color--white);
+
+		@include break-medium() {
+			padding-bottom: 160px;
+		}
 
 		&::after {
 			content: "";
@@ -34,12 +38,12 @@ body.post-type-archive-podcast {
 		}
 
 		.wp-block-query-title {
-			font-size: clamp(38px, 12vw, 50px);
+			font-size: clamp(22px, 12vw, 50px);
 			word-break: break-all;
 			line-height: 1;
 
 			span {
-				font-size: clamp(72px, 12vw, 150px);
+				font-size: clamp(50px, 12vw, 150px);
 			}
 		}
 


### PR DESCRIPTION
When viewing the podcast page on mobile, I noticed the "T" overflows to the next line. This PR reduces the padding and font-size to stop that.

| Before @ `360` | After @ `360` |
|--------|--------|
| ![localhost_8888_podcast_(Samsung Galaxy S8+)](https://github.com/user-attachments/assets/f4ff337e-c1b6-48cd-b519-9462b89da7bc) |![localhost_8888_podcast_(Samsung Galaxy S8+) (2)](https://github.com/user-attachments/assets/8744711c-b2e0-4825-9601-170ce57dc1d6) | 




