### PR TITLE
Show major version on homepage for beta and RC releases.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
+++ b/source/wp-content/themes/wporg-news-2021/block-template-parts/front-page/latest-release.html
@@ -7,7 +7,7 @@
 	<!-- wp:post-template -->
 		<!-- wp:group {"tagName":"header","className":"entry-header"} -->
 		<header class="wp-block-group entry-header">
-			<!-- wp:wporg/release-version {"tagName":"h3","isLink":true} /-->
+			<!-- wp:wporg/release-version {"tagName":"h3","isLink":true,"showMajorVersion":true} /-->
 
 			<!-- wp:group {"className":"entry-meta"} -->
 			<div class="wp-block-group entry-meta">

--- a/source/wp-content/themes/wporg-news-2021/blocks/release-version/block.json
+++ b/source/wp-content/themes/wporg-news-2021/blocks/release-version/block.json
@@ -20,6 +20,10 @@
 		},
 		"textAlign": {
 			"type": "string"
+		},
+		"showMajorVersion": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "postId" ],

--- a/source/wp-content/themes/wporg-news-2021/blocks/release-version/index.php
+++ b/source/wp-content/themes/wporg-news-2021/blocks/release-version/index.php
@@ -21,8 +21,9 @@ function render_block( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$post_ID          = $block->context['postId'];
-	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
+	$post_ID            = $block->context['postId'];
+	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
+	$show_major_version = $attributes['showMajorVersion'];
 
 	$version = '';
 	$title = get_the_title( $post_ID );
@@ -30,10 +31,18 @@ function render_block( $attributes, $content, $block ) {
 	if ( preg_match( '/WordPress (\d{0,3}(?:\.\d{1,3})+)\s*(?|Release Candidate\s*(\d+)|RC\s*(\d+))?(?|Beta\s*(\d+))?/', $title, $matches ) ) {
 		$version = $matches[1];
 		if ( ! empty( $matches[2] ) ) {
-			$version = 'RC' . $matches[2];
+			if ( $show_major_version ) {
+				$version .= ' RC' . $matches[2];
+			} else {
+				$version = 'RC' . $matches[2];
+			}
 		}
 		if ( ! empty( $matches[3] ) ) {
-			$version = 'Beta' . $matches[3];
+			if ( $show_major_version ) {
+				$version .= ' Beta' . $matches[3];
+			} else {
+				$version = 'Beta' . $matches[3];
+			}
 		}
 	}
 

--- a/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss
@@ -68,7 +68,7 @@ body.news-front-page .front__latest-release {
 		@include break-medium() {
 			left: unset;
 			flex-grow: 1;
-			font-size: min(16vw, 160px);
+			font-size: clamp(60px, calc(20vw + -96px), 160px);
 			padding:
 				calc(var(--wp--custom--alignment--edge-spacing) / 2)
 				var(--wp--custom--alignment--edge-spacing)
@@ -93,7 +93,7 @@ body.news-front-page .front__latest-release {
 				padding: 15px 0;
 				transition: background-color 0.15s linear;
 
-				@include break-xlarge() {
+				@media (min-width: 1500px) {
 					&::after {
 						content: "";
 						display: block;


### PR DESCRIPTION
**What**

This modifies the home page of the news section, wordpress.org/news, to display the major version number for beta and release candidates. This changes the text from `BetaX` and `RCX` to `X.X BetaX` and `X.X RCX` respectively.

No change is made to the sidebar of the release listing.

| Before | After |
| --- | --- |
|  ![Screenshot 2024-10-09 at 9 46 09 AM](https://github.com/user-attachments/assets/2fca640f-e7a2-417b-8949-9b0bd07ec065) | ![Screenshot 2024-10-09 at 9 47 11 AM](https://github.com/user-attachments/assets/5d8fa5bd-2d02-4d87-aa6c-242c03234f9c) |
| ![Screenshot 2024-10-09 at 9 49 26 AM](https://github.com/user-attachments/assets/ff2c9718-7bb7-421e-b592-8e59c00399e8) |  ![Screenshot 2024-10-09 at 9 49 05 AM](https://github.com/user-attachments/assets/3e4de652-6da4-4144-903c-83e0ac82a0c9) |

(Please ignore the summary in the second after image, I copied over an old post)

**Why**

On the news home page, the headline is not specific when it contains only the type of pre-release without the major release version. On the release index the sidebar is fine as is as the major version is included on the right of the screen.

**Broken**

On the news home page, this introduces horizontal scrolling on narrow-ish displays. 

![horizontal-scrolling](https://github.com/user-attachments/assets/309e4b9f-9a5c-4f87-9850-3379c4004c43)

I tried removing this block of code from the home page but it was still there so I'm leaving it as a project for y'all. The font size may need to be reduced slightly.

I've allowed edits by maintainers, so feel free to push to my branch at will.

https://github.com/WordPress/wporg-news-2021/blob/abc40e16ab22585570282ee4b352e830919affc6/source/wp-content/themes/wporg-news-2021/sass/page/front-page/_latest-release.scss#L96-L111