### PR TITLE
Styles: Update print styles

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/sass/print/_index.scss
+++ b/source/wp-content/themes/wporg-news-2021/sass/print/_index.scss
@@ -6,8 +6,11 @@
 	}
 
 	html[lang] {
-		margin-top: unset;
 		scroll-padding-top: unset;
+
+		// Admin bar is hidden in print.
+		/* stylelint-disable-next-line length-zero-no-unit */
+		--wp-admin--admin-bar--height: 0px;
 	}
 
 	.wp-site-blocks {
@@ -18,18 +21,40 @@
 		}
 	}
 
-	:root :where(.wp-block-post-title) {
-		--wp--custom--h-1--typography--font-size: 35px;
-	}
-
-	:root :where(body) {
-		--local--block-gap: 15px;
+	:root body[class] {
 		// Reduce font sizes.
-		--wp--preset--font-size--normal: 13px;
+		--wp--preset--font-size--tiny: 12px;
 		--wp--preset--font-size--small: 12px;
+		--wp--preset--font-size--normal: 13px;
+		--wp--preset--font-size--medium: 14px;
+		--wp--preset--font-size--large: 16px;
+		--wp--preset--font-size--x-large: 20px;
+		--wp--preset--font-size--extra-large: 20px;
+		--wp--preset--font-size--huge: 26px;
+
+		--wp--custom--h-6--typography--font-size: 16px;
+		--wp--custom--h-5--typography--font-size: 20px;
+		--wp--custom--h-4--typography--font-size: 24px;
+		--wp--custom--h-3--typography--font-size: 28px;
+		--wp--custom--h-2--typography--font-size: 32px;
+		--wp--custom--h-1--typography--font-size: 36px;
+
+		// Update spacing
+		--wp--preset--spacing--20: 15px;
+		--wp--preset--spacing--30: 20px;
+		--wp--preset--spacing--40: 25px;
+		--wp--preset--spacing--50: 30px;
+		--wp--preset--spacing--60: 35px;
+		--wp--preset--spacing--70: 40px;
+		--wp--preset--spacing--80: 45px;
+		--local--block-gap: 15px;
+
 		// Remove content width constraints.
 		--wp--custom--layout--content-size: 100%;
 		--wp--style--global--content-size: 100%;
+
+		// Shared colors.
+		--wp--preset--color--charcoal-4: #656a71;
 	}
 
 	// Reduce block gap.
@@ -39,16 +64,18 @@
 
 	// Hide elements that are not needed in print.
 	.global-header,
-	.wp-block-wporg-local-navigation-bar,
-	.single .entry-header + .wp-block-separator,
-	.page .entry-header + .wp-block-separator,
+	.wp-block-wporg-local-navigation-bar .wp-block-navigation,
+	.wp-block-wporg-local-navigation-bar::after,
+	.query-title-banner::after,
 	.post-navigation-container,
+	.wp-block-query-pagination,
+	.wp-block-post-excerpt__more-text,
+	.query-title-banner__title__dropcap,
 	.bottom-banner,
 	.global-footer {
 		display: none !important;
 	}
 
-	// Turn grid layout elements to block to enable margins to collapse.
 	.single .entry-header,
 	.page .entry-header,
 	body.news-posts-index .site-content-container,
@@ -60,51 +87,195 @@
 		display: block;
 	}
 
-	// Remove padding from entry header and post content.
-	body.single:not(.single-podcast) .site-content-container .entry-header,
-	body.single:not(.single-podcast) .site-content-container .wp-block-post-content,
-	body.page .site-content-container .entry-header,
-	body.page .site-content-container .wp-block-post-content,
-	body.single-podcast .query-title-banner-podcast,
-	body.post-type-archive-podcast .query-title-banner-podcast,
-	body.single-podcast .site-content-container,
-	body.post-type-archive-podcast .site-content-container {
-		padding-left: unset;
-		padding-right: unset;
+	// Show the navigation bar to give context to the printout.
+	// Double class for specificity.
+	.wp-block-wporg-local-navigation-bar.wp-block-wporg-local-navigation-bar {
+		position: initial !important;
+		justify-content: flex-start !important;
+		border-bottom: 1px solid var(--wp--preset--color--light-grey) !important;
+
+		.global-header__wporg-logo-mark {
+			// Allow the logo to be printed.
+			print-color-adjust: exact;
+			position: initial !important;
+			display: block !important;
+			width: 30px;
+			height: 30px;
+			/* stylelint-disable-next-line function-url-quotes */
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='img' width='28' height='28' viewBox='0 0 28 28'%3E%3Ctitle%3EWordPress.org%3C/title%3E%3Cpath fill='currentColor' d='M13.6052 0.923525C16.1432 0.923525 18.6137 1.67953 20.7062 3.09703C22.7447 4.47403 24.3512 6.41803 25.3097 8.68603C26.9837 12.6415 26.5382 17.164 24.1352 20.7145C22.7582 22.753 20.8142 24.3595 18.5462 25.318C14.5907 26.992 10.0682 26.5465 6.51772 24.1435C4.47922 22.7665 2.87272 20.8225 1.91422 18.5545C0.240225 14.599 0.685725 10.0765 3.08872 6.52603C4.46572 4.48753 6.40973 2.88103 8.67772 1.92253C10.2302 1.26103 11.9177 0.923525 13.6052 0.923525ZM13.6052 0.113525C6.15322 0.113525 0.105225 6.16153 0.105225 13.6135C0.105225 21.0655 6.15322 27.1135 13.6052 27.1135C21.0572 27.1135 27.1052 21.0655 27.1052 13.6135C27.1052 6.16153 21.0572 0.113525 13.6052 0.113525Z' /%3E%3Cpath fill='currentColor' d='M2.36011 13.6133C2.36011 17.9198 4.81711 21.8618 8.70511 23.7383L3.33211 9.03684C2.68411 10.4813 2.36011 12.0338 2.36011 13.6133ZM21.2061 13.0463C21.2061 11.6558 20.7066 10.6973 20.2746 9.94134C19.8426 9.18534 19.1676 8.22684 19.1676 7.30884C19.1676 6.39084 19.9506 5.31084 21.0576 5.31084H21.2061C16.6296 1.11234 9.51511 1.42284 5.31661 6.01284C4.91161 6.45834 4.53361 6.93084 4.20961 7.43034H4.93861C6.11311 7.43034 7.93561 7.28184 7.93561 7.28184C8.54311 7.24134 8.61061 8.13234 8.00311 8.21334C8.00311 8.21334 7.39561 8.28084 6.72061 8.32134L10.8111 20.5118L13.2681 13.1273L11.5131 8.32134C10.9056 8.28084 10.3386 8.21334 10.3386 8.21334C9.73111 8.17284 9.79861 7.25484 10.4061 7.28184C10.4061 7.28184 12.2691 7.43034 13.3626 7.43034C14.4561 7.43034 16.3596 7.28184 16.3596 7.28184C16.9671 7.24134 17.0346 8.13234 16.4271 8.21334C16.4271 8.21334 15.8196 8.28084 15.1446 8.32134L19.2081 20.4173L20.3691 16.7453C20.8821 15.1388 21.1926 14.0048 21.1926 13.0328L21.2061 13.0463ZM13.7946 14.5853L10.4196 24.3998C12.6876 25.0613 15.1041 25.0073 17.3316 24.2243L17.2506 24.0758L13.7946 14.5853ZM23.4741 8.21334C23.5281 8.59134 23.5551 8.98284 23.5551 9.37434C23.5551 10.5218 23.3391 11.8043 22.7046 13.3973L19.2621 23.3333C24.5271 20.2688 26.4036 13.5593 23.4741 8.21334Z' /%3E%3C/svg%3E");
+			background-repeat: no-repeat;
+			background-position: center;
+			background-size: 30px 30px;
+
+			svg {
+				display: none;
+			}
+		}
+
+		.global-header__wporg-logo-mark,
+		.wporg-local-navigation-bar__fade-in-scroll,
+		.wporg-local-navigation-bar__show-on-scroll {
+			opacity: 1;
+			top: 0;
+			visibility: visible;
+		}
 	}
 
-	// Reduce margins for post meta.
-	.single .entry-header .wp-block-post-date,
-	.page .entry-header .wp-block-post-date {
-		margin-top: unset;
+	// Adjust spacing around the separator.
+	.single .entry-header + .wp-block-separator,
+	.page .entry-header + .wp-block-separator {
+		margin-top: var(--wp--preset--spacing--50);
+		margin-bottom: var(--wp--preset--spacing--50);
 	}
 
-	// Reduce margins for post title.
-	.single .entry-header .wp-block-post-title,
-	.page .entry-header .wp-block-post-title {
-		margin-top: var(--local--block-gap);
-		margin-bottom: calc(var(--local--block-gap) * 2);
+	// Fix the spacing around query title banners.
+	.query-title-banner {
+		padding-top: 0;
+		padding-bottom: var(--wp--preset--spacing--50);
+		transform: none;
+		background: transparent;
+		color: var(--wp--preset--color--black);
+	}
+
+	// Reduce spacing between posts on archives.
+	.blog .wp-block-post,
+	.category:not(.category-community):not(.category-events):not(.category-releases) .wp-block-post {
+		margin-bottom: 0;
+	}
+
+	/* Block styles. */
+
+	// Add an indication that blocks have a background.
+	.wp-block-group:not(.alignfull).has-background,
+	.wp-block-wporg-notice,
+	p.has-background {
+		border: 1px solid currentColor;
+	}
+
+	// Set white text to a dark grey for better contrast.
+	.has-white-color {
+		color: var(--wp--preset--color--charcoal-4) !important;
+
+		a:where(:not(.wp-element-button)) {
+			color: var(--wp--preset--color--charcoal-4) !important;
+		}
+	}
+
+	// Style buttons.
+	[class*="wp-block"]:not(.is-style-outline) .wp-block-button__link {
+		color: var(--wp--preset--color--blue-1);
+		background-color: transparent;
+		border: 1px solid var(--wp--preset--color--blue-1);
+	}
+
+	// Shrink font size on quotes.
+	.wp-block-quote {
+		font-size: var(--wp--preset--font-size--extra-large);
+	}
+
+	// Hide video blocks.
+	.wp-block-video {
+		display: none !important;
+	}
+
+	.wp-block-group:has(> .wp-block-video:only-child) {
+		display: none !important;
 	}
 
 	// Reduce image size and spacing to reduce the number of page breaks.
-	.wp-block-post-content .wp-block-gallery,
-	.wp-block-post-content .wp-block-image {
-		margin-top: var(--local--block-gap);
-		margin-bottom: var(--local--block-gap);
-
-		img {
+	.wp-block-gallery,
+	.wp-block-image {
+		img:not([style*="height:"]) {
 			max-width: 67%;
 		}
 	}
 
-	// Reduce caption font size and align center to match image.
-	.wp-block-gallery.wp-block-gallery figcaption,
-	figure[class*="wp-block-"] figcaption,
-	[class*="wp-block-"] figcaption {
-		--wp--custom--gallery--caption--font-size: var(--wp--preset--font-size--small);
+	/* Homepage specific styles */
+	body.news-front-page {
+		.wp-block-wporg-local-navigation-bar,
+		.front__site-title::after,
+		.front__next-page {
+			display: none;
+		}
 
-		line-height: 1.5;
-		text-align: center;
+		.front__site-title {
+			margin-bottom: 0;
+			font-size: var(--wp--custom--h-1--typography--font-size);
+			color: var(--wp--preset--color--black);
+		}
+
+		.front__latest-release {
+			border-bottom: 1px solid var(--wp--preset--color--light-grey) !important;
+			color: var(--wp--preset--color--black) !important;
+
+			.front__latest-release-heading {
+				padding-top: 0;
+				font-size: var(--wp--custom--h-2--typography--font-size);
+				color: var(--wp--preset--color--black);
+			}
+
+			.wp-block-wporg-release-version {
+				font-size: var(--wp--custom--h-1--typography--font-size);
+
+				a {
+					color: inherit;
+				}
+			}
+		}
+
+		.front__latest-posts {
+			.front__latest-posts-heading {
+				padding: 0;
+			}
+
+			.wp-block-post-template h3 {
+				font-size: var(--wp--custom--h-3--typography--font-size);
+			}
+
+			.wp-block-post-template > li {
+				margin-bottom: 0;
+			}
+		}
+
+		.front__people-of-wordpress {
+			border-top: 1px solid var(--wp--preset--color--light-grey) !important;
+
+			.front__people-of-wordpress-heading {
+				padding-top: var(--wp--preset--spacing--50);
+				padding-bottom: var(--wp--preset--spacing--50);
+				font-size: var(--wp--custom--h-2--typography--font-size);
+			}
+
+			.wp-block-post-template {
+				display: flex;
+				flex-wrap: wrap;
+				gap: 0 var(--local--block-gap);
+
+				.wp-block-post {
+					max-width: 2in;
+					overflow: initial;
+					border: 1px solid var(--wp--preset--color--light-grey);
+
+					.wp-block-post-title {
+						margin: 0;
+
+						a {
+							position: initial;
+							color: var(--wp--preset--color--black);
+						}
+					}
+
+					&.has-post-thumbnail .wp-block-post-title a {
+						opacity: 1;
+					}
+
+					&:not(.has-post-thumbnail) {
+						aspect-ratio: unset;
+						background-color: unset;
+					}
+				}
+			}
+		}
 	}
 
 	/* Podcast specific styles */


### PR DESCRIPTION
Fixes #427 — This brings over some of the print styles added to the parent theme in https://github.com/WordPress/wporg-parent-2021/issues/158 to address the follow-up comments on #427.

This PR relies on #431 for the local navigation bar. Once merged, that can be used for context in print like it is on the rest of the website. The other changes here are fixes for the homepage, mostly reducing the font size and space between elements, and fixing the people of WP images.

Example PDFs printed from Chrome:

- [Home (pdf)](https://github.com/user-attachments/files/17512919/wp-news-home.pdf)
- [Single post (pdf)](https://github.com/user-attachments/files/17512918/wp-news-post.pdf)
- [Category archive (pdf)](https://github.com/user-attachments/files/17512920/wp-news-cat.pdf)
