### PR TITLE
Opt into margin and padding controls for the theme.

### DIFF
--- a/source/wp-content/themes/wporg-news-2021/theme.json
+++ b/source/wp-content/themes/wporg-news-2021/theme.json
@@ -392,6 +392,8 @@
 			"blockGap": true,
 			"units": [ "%", "px", "em", "rem", "vh", "vw" ],
 			"customSpacingSize": true,
+			"padding": true,
+			"margin": true,
 			"spacingSizes": [
 				{
 					"name": "Edge Spacing",


### PR DESCRIPTION
This PR sets `spacing.padding` and `spacing.margin` to true to opt into those controls for blocks.

Closes #440 